### PR TITLE
Change order late field paths are resolved

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -1326,6 +1326,9 @@ class StructAccess(Expression):
 
         if self.field_path is None and not self.checked_late_field_path:
             var = late_unwrap(self.struct_var)
+            # Format var to recursively resolve any late_field_path it has to
+            # potentially improve var.type before we look up our field name
+            var.format(Formatter())
             field_path, field_type, _ = var.type.get_deref_field(
                 self.offset, target_size=self.target_size
             )


### PR DESCRIPTION
This improves type resolution in expressions like `x->unk4->unk8` by performing late field path resolution from left-to-right
(inner-to-outer) instead of right-to-left.

Before, first the `->unk8` was resolved on `x->unk4`, which would likely have unknown type. This changes the orderr to resolve `->unk4` on `x` first.

Diffs in OOT/MM/PM projects (I don't have any context files for the PPC projects):
https://gist.github.com/zbanks/8ef17548d110a8bfd7f557d7d898537b

---

I admit that using `var.format(...)` is a bit hacky: it's "O(n^2)-like" -- but the pros are:
- It's in the block of `StructAccess.late_field_path()` that's only called once per instance
- Putting it in `StructAccess.late_field_path()` fixes the issue for both `StructAccess.format()` *and* `StructAccess. late_has_known_type()`
- Very simple to traverse `var` -- supports more than just `isinstance(var, StructAccess)`
