### PR TITLE
Move instruction logic out of translate.py and into arch_*.py

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -1,6 +1,7 @@
 from dataclasses import replace
 import typing
 from typing import (
+    Callable,
     Dict,
     List,
     Optional,
@@ -43,11 +44,15 @@ from .translate import (
     Cast,
     CmpInstrMap,
     CommentStmt,
+    ExprCondition,
+    ExprStmt,
     ErrorExpr,
     Expression,
+    InstrArgs,
     InstrMap,
     InstrSet,
     Literal,
+    NodeState,
     PairInstrMap,
     SecondF64Half,
     StmtInstrMap,
@@ -679,6 +684,7 @@ class MipsArch(Arch):
         is_branch_likely = False
         is_conditional = False
         is_return = False
+        eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
 
         memory_sizes = {
             "b": 1,
@@ -714,6 +720,7 @@ class MipsArch(Arch):
             jump_target = args[0]
             is_conditional = True
             has_delay_slot = True
+            eval_fn = lambda s, a: s.set_switch_expr(a.reg(0))
         elif mnemonic == "jal" or mnemonic == "bal":
             # Function call to label
             assert len(args) == 1 and isinstance(args[0], AsmGlobalSymbol)
@@ -771,6 +778,13 @@ class MipsArch(Arch):
             has_delay_slot = True
             is_branch_likely = True
             is_conditional = True
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                assert (
+                    False
+                ), "Branch-likely instructions should be rewritten by flow_graph.py"
+
+            eval_fn = _eval
         elif mnemonic in (
             "beq",
             "bne",
@@ -800,15 +814,35 @@ class MipsArch(Arch):
             jump_target = get_jump_target(args[-1])
             has_delay_slot = True
             is_conditional = True
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                if mnemonic in ("bc1t", "bc1f"):
+                    cond = a.regs[Register("condition_bit")]
+                    if not isinstance(cond, BinaryOp):
+                        cond = ExprCondition(cond, type=cond.type)
+                    if mnemonic == "bc1f":
+                        cond = cond.negated()
+                else:
+                    cond = cls.instrs_branches[mnemonic](a)
+                s.set_branch_condition(cond)
+
+            eval_fn = _eval
         elif mnemonic == "mfc0":
             assert len(args) == 2 and isinstance(args[0], Register)
             outputs = [args[0]]
+            eval_fn = lambda s, a: s.set_reg(
+                a.reg_ref(0), ErrorExpr(f"mfc0 {a.raw_arg(1)}")
+            )
         elif mnemonic == "mtc0":
             assert len(args) == 2 and isinstance(args[0], Register)
             inputs = [args[0]]
+            eval_fn = lambda s, a: s.to_write.append(
+                error_stmt(f"mtc0 {a.raw_arg(0)}, {a.raw_arg(1)}")
+            )
         elif mnemonic in cls.instrs_no_dest:
             assert not any(isinstance(a, AsmAddressMode) for a in args)
             inputs = [r for r in args if isinstance(r, Register)]
+            eval_fn = lambda s, a: s.to_write.append(cls.instrs_no_dest[mnemonic](a))
         elif mnemonic in cls.instrs_store:
             assert isinstance(args[0], Register)
             inputs = [args[0]]
@@ -817,6 +851,15 @@ class MipsArch(Arch):
                 inputs.append(args[1].rhs)
             if mnemonic == "sdc1":
                 inputs.append(args[0].other_f64_reg())
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                store = cls.instrs_store[mnemonic](a)
+                if store is not None:
+                    s.store_memory(
+                        source=store.source, dest=store.dest, reg=a.reg_ref(0)
+                    )
+
+            eval_fn = _eval
         elif mnemonic in cls.instrs_source_first:
             assert (
                 len(args) == 2
@@ -825,6 +868,9 @@ class MipsArch(Arch):
             )
             inputs = [args[0]]
             outputs = [args[1]]
+            eval_fn = lambda s, a: s.set_reg(
+                a.reg_ref(1), cls.instrs_source_first[mnemonic](a)
+            )
         elif mnemonic in cls.instrs_destination_first:
             assert isinstance(args[0], Register)
             outputs = [args[0]]
@@ -884,6 +930,14 @@ class MipsArch(Arch):
             else:
                 assert not any(isinstance(a, AsmAddressMode) for a in args)
                 inputs = [r for r in args[1:] if isinstance(r, Register)]
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                target = a.reg_ref(0)
+                s.set_reg(target, cls.instrs_destination_first[mnemonic](a))
+                if len(outputs) == 2:
+                    s.set_reg(target.other_f64_reg(), SecondF64Half())
+
+            eval_fn = _eval
         elif mnemonic in cls.instrs_float_comp:
             assert (
                 len(args) == 2
@@ -900,6 +954,9 @@ class MipsArch(Arch):
             else:
                 inputs = [args[0], args[1]]
             outputs = [Register("condition_bit")]
+            eval_fn = lambda s, a: s.set_reg_without_eval(
+                Register("condition_bit"), cls.instrs_float_comp[mnemonic](a)
+            )
         elif mnemonic in cls.instrs_hi_lo:
             assert (
                 len(args) == 2
@@ -908,6 +965,13 @@ class MipsArch(Arch):
             )
             inputs = [args[0], args[1]]
             outputs = [Register("hi"), Register("lo")]
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                hi, lo = cls.instrs_hi_lo[mnemonic](a)
+                s.set_reg(Register("hi"), hi)
+                s.set_reg(Register("lo"), lo)
+
+            eval_fn = _eval
         elif mnemonic in cls.instrs_ignore:
             # TODO: There might be some instrs to handle here
             pass
@@ -916,6 +980,15 @@ class MipsArch(Arch):
             assert not any(isinstance(a, AsmAddressMode) for a in args)
             inputs = [r for r in args[1:] if isinstance(r, Register)]
             outputs = [args[0]]
+
+            def _eval(s: NodeState, a: InstrArgs) -> None:
+                error = f"unknown instruction: {AsmInstruction(mnemonic, args)}"
+                if a.count() >= 1 and isinstance(a.raw_arg(0), Register):
+                    s.set_reg_with_error(a.reg_ref(0), ErrorExpr(error))
+                else:
+                    s.to_write.append(error_stmt(error))
+
+            eval_fn = _eval
 
         return Instruction(
             mnemonic=mnemonic,
@@ -930,6 +1003,7 @@ class MipsArch(Arch):
             is_branch_likely=is_branch_likely,
             is_conditional=is_conditional,
             is_return=is_return,
+            eval_fn=eval_fn,
         )
 
     asm_patterns = [
@@ -1039,7 +1113,7 @@ class MipsArch(Arch):
             "M2C_BREAK", [a.imm(0)] if a.count() >= 1 else []
         ),
         "sync": lambda a: void_fn_op("M2C_SYNC", []),
-        "mtc0": lambda a: error_stmt(f"mtc0 {a.raw_arg(0)}, {a.raw_arg(1)}"),
+        # "mtc0": lambda a: error_stmt(f"mtc0 {a.raw_arg(0)}, {a.raw_arg(1)}"),
         "trapuv.fictive": lambda a: CommentStmt("code compiled with -trapuv"),
     }
     instrs_float_comp: CmpInstrMap = {
@@ -1278,7 +1352,7 @@ class MipsArch(Arch):
         # FCSR get
         "cfc1": lambda a: ErrorExpr("cfc1"),
         # Read from coprocessor 0
-        "mfc0": lambda a: ErrorExpr(f"mfc0 {a.raw_arg(1)}"),
+        # "mfc0": lambda a: ErrorExpr(f"mfc0 {a.raw_arg(1)}"),
         # Immediates
         "li": lambda a: a.full_imm(1),
         "lui": lambda a: load_upper(a),

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -734,6 +734,7 @@ class MipsArch(Arch):
             clobbers = list(cls.temp_regs)
             function_target = args[0]
             has_delay_slot = True
+            eval_fn = lambda s, a: s.make_function_call(a.sym_imm(0), outputs)
         elif mnemonic == "jalr":
             # Function call to pointer
             assert (
@@ -747,6 +748,7 @@ class MipsArch(Arch):
             clobbers = list(cls.temp_regs)
             function_target = args[1]
             has_delay_slot = True
+            eval_fn = lambda s, a: s.make_function_call(a.reg(1), outputs)
         elif mnemonic in ("b", "j"):
             # Unconditional jump
             assert len(args) == 1
@@ -857,7 +859,7 @@ class MipsArch(Arch):
                         source=store.source, dest=store.dest, reg=a.reg_ref(0)
                     )
 
-        elif mnemonic in "mtc1":
+        elif mnemonic == "mtc1":
             # Floating point moving instruction, source first
             assert (
                 len(args) == 2

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -836,11 +836,11 @@ class MipsArch(Arch):
         elif mnemonic == "mtc0":
             assert len(args) == 2 and isinstance(args[0], Register)
             inputs = [args[0]]
-            eval_fn = lambda s, a: s.to_write.append(error_stmt(instr_str))
+            eval_fn = lambda s, a: s.write_statement(error_stmt(instr_str))
         elif mnemonic in cls.instrs_no_dest:
             assert not any(isinstance(a, AsmAddressMode) for a in args)
             inputs = [r for r in args if isinstance(r, Register)]
-            eval_fn = lambda s, a: s.to_write.append(cls.instrs_no_dest[mnemonic](a))
+            eval_fn = lambda s, a: s.write_statement(cls.instrs_no_dest[mnemonic](a))
         elif mnemonic in cls.instrs_store:
             assert isinstance(args[0], Register)
             inputs = [args[0]]
@@ -982,7 +982,7 @@ class MipsArch(Arch):
                 if maybe_dest_first:
                     s.set_reg_with_error(a.reg_ref(0), ErrorExpr(error))
                 else:
-                    s.to_write.append(error_stmt(error))
+                    s.write_statement(error_stmt(error))
 
         return Instruction(
             mnemonic=mnemonic,

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -1,6 +1,7 @@
 from dataclasses import replace
 import typing
 from typing import (
+    Callable,
     ClassVar,
     Dict,
     List,
@@ -51,11 +52,13 @@ from .translate import (
     ErrorExpr,
     Expression,
     ImplicitInstrMap,
+    InstrArgs,
     InstrMap,
     InstrSet,
     Literal,
-    PpcCmpInstrMap,
+    NodeState,
     PairInstrMap,
+    PpcCmpInstrMap,
     SecondF64Half,
     StmtInstrMap,
     StoreInstrMap,
@@ -512,6 +515,7 @@ class PpcArch(Arch):
         function_target: Optional[Union[AsmGlobalSymbol, Register]] = None
         is_conditional = False
         is_return = False
+        eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
 
         cr0_bits: List[Location] = [
             Register("cr0_lt"),
@@ -764,6 +768,7 @@ class PpcArch(Arch):
             function_target=function_target,
             is_conditional=is_conditional,
             is_return=is_return,
+            eval_fn=eval_fn,
         )
 
     ir_patterns = [

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -781,7 +781,7 @@ class PpcArch(Arch):
             eval_fn = None
         elif mnemonic in cls.instrs_no_dest:
             assert not any(isinstance(a, (Register, AsmAddressMode)) for a in args)
-            eval_fn = lambda s, a: s.to_write.append(cls.instrs_no_dest[mnemonic](a))
+            eval_fn = lambda s, a: s.write_statement(cls.instrs_no_dest[mnemonic](a))
         elif mnemonic.rstrip(".") in cls.instrs_destination_first:
             assert isinstance(args[0], Register)
             outputs = [args[0]]
@@ -894,7 +894,7 @@ class PpcArch(Arch):
                 if maybe_dest_first:
                     s.set_reg_with_error(a.reg_ref(0), ErrorExpr(error))
                 else:
-                    s.to_write.append(error_stmt(error))
+                    s.write_statement(error_stmt(error))
 
         return Instruction(
             mnemonic=mnemonic,

--- a/src/instruction.py
+++ b/src/instruction.py
@@ -115,6 +115,13 @@ class Instruction:
     clobbers: List[Location]
     outputs: List[Location]
 
+    # This should be typed as `eval_fn: Optional[Callable[[NodeState, InstrArgs], object]]`
+    # but this use classes that are defined in translate.py. We're unable to use correct
+    # types here without creating circular dependencies.
+    # The return value is ignored, but is typed as `object` so lambdas are more ergonomic.
+    # This member should only be accessed by `evaluate_instruction`.
+    eval_fn: Optional[Callable[..., object]]
+
     jump_target: Optional[Union[JumpTarget, Register]] = None
     function_target: Optional[Union[AsmGlobalSymbol, Register]] = None
     is_conditional: bool = False
@@ -128,9 +135,6 @@ class Instruction:
 
     # True if the Instruction was part of a matched IR pattern, but not elided
     in_pattern: bool = False
-
-    # TODO: Document
-    eval_fn: Optional[Callable[..., object]] = None
 
     def is_jump(self) -> bool:
         return self.jump_target is not None or self.is_return

--- a/src/instruction.py
+++ b/src/instruction.py
@@ -1,7 +1,7 @@
 import abc
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from typing import Iterator, List, Optional, Union
+from typing import Callable, Iterator, List, Optional, Union
 
 from .error import DecompFailure
 from .options import Target
@@ -128,6 +128,9 @@ class Instruction:
 
     # True if the Instruction was part of a matched IR pattern, but not elided
     in_pattern: bool = False
+
+    # TODO: Document
+    eval_fn: Optional[Callable[..., object]] = None
 
     def is_jump(self) -> bool:
         return self.jump_target is not None or self.is_return

--- a/src/ir_pattern.py
+++ b/src/ir_pattern.py
@@ -83,6 +83,7 @@ class IrPattern(abc.ABC):
                     inputs=[],
                     clobbers=[],
                     outputs=[inp],
+                    eval_fn=None,
                 )
             )
         for part in self.parts:


### PR DESCRIPTION
Add `Instruction.eval_fn` and set it in `Arch.parse(...)` to move instruction evaluation logic out of translate.py. 

I also refactored some of the `instrs_*` members: now they're only referenced in a single function, so they no longer need to be as generic. 

The only output changes from this PR are in the tracebacks for certain errors. 