### PR TITLE
Add support for MIPS add, sub, and bal instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
 

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -543,8 +543,8 @@ class Bounds:
     conditional branches.
     """
 
-    lower: int = -(2 ** 31)  # `INT32_MAX`
-    upper: int = (2 ** 32) - 1  # `UINT32_MAX`
+    lower: int = -(2**31)  # `INT32_MAX`
+    upper: int = (2**32) - 1  # `UINT32_MAX`
     holes: Set[int] = field(default_factory=set)
 
     def __post_init__(self) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -576,7 +576,7 @@ def parse_flags(flags: List[str]) -> Options:
 def main() -> None:
     # Large functions can sometimes require a higher recursion limit than the
     # CPython default. Cap to INT_MAX to avoid an OverflowError, though.
-    sys.setrecursionlimit(min(2 ** 31 - 1, 10 * sys.getrecursionlimit()))
+    sys.setrecursionlimit(min(2**31 - 1, 10 * sys.getrecursionlimit()))
     options = parse_flags(sys.argv[1:])
     sys.exit(run(options))
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -1549,7 +1549,7 @@ class Literal(Expression):
                 and size_bits
                 and v & (1 << (size_bits - 1))
                 and v > (3 << (size_bits - 2))
-                and v < 2 ** size_bits
+                and v < 2**size_bits
             ):
                 v -= 1 << size_bits
             value = fmt.format_int(v, size_bits=size_bits)
@@ -1557,7 +1557,7 @@ class Literal(Expression):
         return prefix + value + suffix
 
     def likely_partial_offset(self) -> bool:
-        return self.value % 2 ** 15 in (0, 2 ** 15 - 1) and self.value < 0x1000000
+        return self.value % 2**15 in (0, 2**15 - 1) and self.value < 0x1000000
 
 
 @dataclass(frozen=True, eq=True)
@@ -2259,7 +2259,7 @@ def deref(
     # Struct member is being dereferenced.
 
     # Cope slightly better with raw pointers.
-    if isinstance(var, Literal) and var.value % (2 ** 16) == 0:
+    if isinstance(var, Literal) and var.value % (2**16) == 0:
         var = Literal(var.value + offset, type=var.type)
         offset = 0
 
@@ -2935,7 +2935,7 @@ def handle_conditional_move(args: InstrArgs, nonzero: bool) -> Expression:
 
 
 def format_f32_imm(num: int) -> str:
-    packed = struct.pack(">I", num & (2 ** 32 - 1))
+    packed = struct.pack(">I", num & (2**32 - 1))
     value = struct.unpack(">f", packed)[0]
 
     if not value or value == 4294967296.0:
@@ -2990,7 +2990,7 @@ def format_f32_imm(num: int) -> str:
 
 
 def format_f64_imm(num: int) -> str:
-    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2 ** 64 - 1)))
+    (value,) = struct.unpack(">d", struct.pack(">Q", num & (2**64 - 1)))
     return str(value)
 
 
@@ -4313,7 +4313,7 @@ def process_instruction(instr: Instruction, state: NodeState) -> None:
             assert False, f"Unhandled jump mnemonic {arch_mnemonic}"
 
     elif mnemonic in arch.instrs_fn_call:
-        if arch_mnemonic in ["mips:jal", "ppc:bl"]:
+        if arch_mnemonic in ["mips:jal", "mips:bal", "ppc:bl"]:
             fn_target = args.imm(0)
             if not (
                 (

--- a/tests/ppc_disasm.py
+++ b/tests/ppc_disasm.py
@@ -244,16 +244,12 @@ def instruction_to_text(insn: CsInsn, raw: int, section: ElfSection) -> Optional
             )
 
     # Sign-extend immediate values (Capstone doesn't do that automatically)
-    if (
-        insn.id
-        in {
-            cs.ppc.PPC_INS_ADDI,
-            cs.ppc.PPC_INS_ADDIC,
-            cs.ppc.PPC_INS_SUBFIC,
-            cs.ppc.PPC_INS_MULLI,
-        }
-        and (insn.operands[2].imm & 0x8000)
-    ):
+    if insn.id in {
+        cs.ppc.PPC_INS_ADDI,
+        cs.ppc.PPC_INS_ADDIC,
+        cs.ppc.PPC_INS_SUBFIC,
+        cs.ppc.PPC_INS_MULLI,
+    } and (insn.operands[2].imm & 0x8000):
         return "%s %s, %s, %i" % (
             insn.mnemonic,
             insn.reg_name(insn.operands[0].reg),


### PR DESCRIPTION
As best as I can tell `bal` is nearly equivalent to `jal`,
 with the difference being that `bal` can only be used if the
 function being called is in the same file.

That is to say, `bal` indicates that the function being
 called is position-independent code.

Also includes some formatting updates from black

Signed-off-by: Taggerung <tyler.taggerung@gmail.com>