### PR TITLE
Allow context arg to accept multiple files

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -251,7 +251,8 @@ def parse_flags(flags: List[str]) -> Options:
         "--context",
         metavar="C_FILE",
         dest="c_contexts",
-        action="append",
+        action="extend",
+        nargs="+",
         type=Path,
         default=[],
         help="Read variable types/function signatures/structs from an existing C file. "


### PR DESCRIPTION
Given 3 context files, these changes make the following invocations valid:

`m2c.py some_asm.s --context ctx_1.c ctx_2.c ctx_3.c`
`m2c.py some_asm.s --context ctx_1.c --context ctx_2.c --context ctx_3.c`
`m2c.py some_asm.s --context ctx_1.c --context ctx_2.c ctx_3.c`

Note that the use of `extend` for `action` requires Python 3.8 or later

Signed-off-by: Taggerung <tyler.taggerung@gmail.com>