### PR TITLE
EvalOnce-wrap everything in RegInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ To get pretty graph visualizations, install `graphviz` using `pip` and globally 
 
 There is a small test suite, which works as follows:
  - As you develop your commit, occasionally run `./run_tests.py` to see if any tests have changed output.
-   These tests run the decompiler on a small corpus of IDO 5.3-compiled MIPS assembly.
+   These tests run the decompiler on a small corpus of assembly.
  - Before pushing your commit, run `./run_tests.py --overwrite` to write changed tests to disk, and commit resultant changes.
 
 ### Running Decompilation Project Tests

--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -68,6 +68,7 @@ from .translate import (
     as_u32,
     as_u64,
     as_uintish,
+    condition_from_expr,
     error_stmt,
     fn_op,
     fold_divmod,
@@ -820,9 +821,7 @@ class MipsArch(Arch):
 
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
                 if mnemonic in ("bc1t", "bc1f"):
-                    cond = a.regs[Register("condition_bit")]
-                    if not isinstance(cond, BinaryOp):
-                        cond = ExprCondition(cond, type=cond.type)
+                    cond = condition_from_expr(a.regs[Register("condition_bit")])
                     if mnemonic == "bc1f":
                         cond = cond.negated()
                 else:
@@ -951,7 +950,7 @@ class MipsArch(Arch):
             else:
                 inputs = [args[0], args[1]]
             outputs = [Register("condition_bit")]
-            eval_fn = lambda s, a: s.set_reg_without_eval(
+            eval_fn = lambda s, a: s.set_reg(
                 Register("condition_bit"), cls.instrs_float_comp[mnemonic](a)
             )
         elif mnemonic in cls.instrs_hi_lo:

--- a/src/translate.py
+++ b/src/translate.py
@@ -113,7 +113,7 @@ def as_type(expr: "Expression", type: Type, silent: bool) -> "Expression":
     type = type.weaken_void_ptr()
     ptr_target_type = type.get_pointer_target()
     if expr.type.unify(type):
-        if silent or isinstance(early_unwrap(expr), Literal):
+        if silent or isinstance(expr, Literal):
             return expr
     elif ptr_target_type is not None:
         ptr_target_type_size = ptr_target_type.get_size_bytes()
@@ -2006,14 +2006,15 @@ class RegInfo:
         meta.is_read = True
         if meta.inherited:
             self.read_inherited.add(key)
-        if (
-            isinstance(ret, EvalOnceExpr)
-            and isinstance(ret.wrapped_expr, PassedInArg)
-            and meta.initial
-        ):
+        uw_ret = early_unwrap(ret)
+        if isinstance(uw_ret, Literal):
+            # Requiring early_unwrap at every place that wants to check if an input
+            # is a literal is a bit noisy, so we unwrap here instead.
+            return uw_ret
+        if isinstance(uw_ret, PassedInArg) and meta.initial:
             # Use accessed argument registers as a signal for determining which
             # arguments actually exist.
-            val, arg = self.stack_info.get_argument(ret.wrapped_expr.value)
+            val, arg = self.stack_info.get_argument(uw_ret.value)
             self.stack_info.add_argument(arg)
             val.type.unify(ret.type)
         if meta.force:
@@ -2142,8 +2143,7 @@ class InstrArgs:
             return ret
 
         # MIPS: Look at the paired FPR to get the full 64-bit value
-        uw_ret = early_unwrap(ret)
-        if not isinstance(uw_ret, Literal) or uw_ret.type.get_size_bits() == 64:
+        if not isinstance(ret, Literal) or ret.type.get_size_bits() == 64:
             return ret
         reg_num = int(reg.register_name[1:])
         if reg_num % 2 != 0:
@@ -2151,14 +2151,14 @@ class InstrArgs:
                 "Tried to use a double-precision instruction with odd-numbered float "
                 f"register {reg}"
             )
-        other = early_unwrap(self.regs[Register(f"f{reg_num+1}")])
+        other = self.regs[Register(f"f{reg_num+1}")]
         if not isinstance(other, Literal) or other.type.get_size_bits() == 64:
             raise DecompFailure(
                 f"Unable to determine a value for double-precision register {reg} "
                 "whose second half is non-static. This is a m2c restriction "
                 "which may be lifted in the future."
             )
-        value = uw_ret.value | (other.value << 32)
+        value = ret.value | (other.value << 32)
         return Literal(value, type=Type.f64())
 
     def cmp_reg(self, key: str) -> Condition:
@@ -2261,12 +2261,12 @@ def deref(
     # Struct member is being dereferenced.
 
     # Cope slightly better with raw pointers.
-    uw_var = early_unwrap(var)
-    if isinstance(uw_var, Literal) and uw_var.value % (2**16) == 0:
-        uw_var = var = Literal(uw_var.value + offset, type=uw_var.type)
+    if isinstance(var, Literal) and var.value % (2**16) == 0:
+        var = Literal(var.value + offset, type=var.type)
         offset = 0
 
     # Handle large struct offsets.
+    uw_var = early_unwrap(var)
     if isinstance(uw_var, BinaryOp) and uw_var.op == "+":
         for base, addend in [(uw_var.left, uw_var.right), (uw_var.right, uw_var.left)]:
             if isinstance(addend, Literal) and addend.likely_partial_offset():
@@ -2639,13 +2639,11 @@ def handle_or(left: Expression, right: Expression) -> Expression:
         # `or $rD, $rS, $rS` can be used to move $rS into $rD
         return left
 
-    uw_left = early_unwrap(left)
-    uw_right = early_unwrap(right)
-    if isinstance(uw_left, Literal) and isinstance(uw_right, Literal):
-        if (((uw_left.value & 0xFFFF) == 0 and (uw_right.value & 0xFFFF0000) == 0)) or (
-            (uw_right.value & 0xFFFF) == 0 and (uw_left.value & 0xFFFF0000) == 0
+    if isinstance(left, Literal) and isinstance(right, Literal):
+        if (((left.value & 0xFFFF) == 0 and (right.value & 0xFFFF0000) == 0)) or (
+            (right.value & 0xFFFF) == 0 and (left.value & 0xFFFF0000) == 0
         ):
-            return Literal(value=(uw_left.value | uw_right.value))
+            return Literal(value=(left.value | right.value))
     # Regular bitwise OR.
     return BinaryOp.int(left=left, op="|", right=right)
 
@@ -2690,16 +2688,16 @@ def handle_addi(args: InstrArgs) -> Expression:
     # `(x + 0xEDCC)` is emitted as `((x + 0x10000) - 0x1234)`,
     # i.e. as an `addis` followed by an `addi`
     uw_source = early_unwrap(source)
-    if isinstance(uw_source, BinaryOp) and uw_source.op == "+":
-        uw_right = early_unwrap(uw_source.right)
-        if (
-            isinstance(uw_right, Literal)
-            and uw_right.value % 0x10000 == 0
-            and isinstance(imm, Literal)
-        ):
-            return add_imm(
-                uw_source.left, Literal(imm.value + uw_right.value), stack_info
-            )
+    if (
+        isinstance(uw_source, BinaryOp)
+        and uw_source.op == "+"
+        and isinstance(uw_source.right, Literal)
+        and uw_source.right.value % 0x10000 == 0
+        and isinstance(imm, Literal)
+    ):
+        return add_imm(
+            uw_source.left, Literal(imm.value + uw_source.right.value), stack_info
+        )
     return handle_addi_real(args.reg_ref(0), source_reg, source, imm, stack_info)
 
 
@@ -2774,13 +2772,11 @@ def add_imm(source: Expression, imm: Expression, stack_info: StackInfo) -> Expre
                         left=source, op="+", right=as_intish(imm), type=source.type
                     )
         return BinaryOp(left=source, op="+", right=as_intish(imm), type=Type.ptr())
+    elif isinstance(source, Literal) and isinstance(imm, Literal):
+        return Literal(source.value + imm.value)
     else:
-        uw_source = early_unwrap(source)
-        if isinstance(uw_source, Literal) and isinstance(imm, Literal):
-            return Literal(uw_source.value + imm.value)
-        else:
-            # Regular binary addition.
-            return BinaryOp.intptr(left=source, op="+", right=imm)
+        # Regular binary addition.
+        return BinaryOp.intptr(left=source, op="+", right=imm)
 
 
 def handle_load(args: InstrArgs, type: Type) -> Expression:
@@ -3335,13 +3331,15 @@ def array_access_from_add(
     index = addend
     scale = 1
     uw_addend = early_unwrap(addend)
-    if isinstance(uw_addend, BinaryOp) and uw_addend.op in ("*", "<<"):
-        uw_right = early_unwrap(uw_addend.right)
-        if isinstance(uw_right, Literal):
-            index = uw_addend.left
-            scale = uw_right.value
-            if uw_addend.op == "<<":
-                scale = 1 << scale
+    if (
+        isinstance(uw_addend, BinaryOp)
+        and uw_addend.op in ("*", "<<")
+        and isinstance(uw_addend.right, Literal)
+    ):
+        index = uw_addend.left
+        scale = uw_addend.right.value
+        if uw_addend.op == "<<":
+            scale = 1 << scale
 
     if scale < 0:
         scale = -scale
@@ -3461,16 +3459,10 @@ def handle_add(args: InstrArgs) -> Expression:
 
     # addiu instructions can sometimes be emitted as addu instead, when the
     # offset is too large.
-    uw_lhs = early_unwrap(lhs)
-    uw_rhs = early_unwrap(rhs)
-    if isinstance(uw_rhs, Literal):
-        return handle_addi_real(
-            args.reg_ref(0), args.reg_ref(1), lhs, uw_rhs, stack_info
-        )
-    if isinstance(uw_lhs, Literal):
-        return handle_addi_real(
-            args.reg_ref(0), args.reg_ref(2), rhs, uw_lhs, stack_info
-        )
+    if isinstance(rhs, Literal):
+        return handle_addi_real(args.reg_ref(0), args.reg_ref(1), lhs, rhs, stack_info)
+    if isinstance(lhs, Literal):
+        return handle_addi_real(args.reg_ref(0), args.reg_ref(2), rhs, lhs, stack_info)
 
     expr = BinaryOp(left=as_intptr(lhs), op="+", right=as_intptr(rhs), type=type)
     folded_expr = fold_mul_chains(expr)
@@ -3550,10 +3542,9 @@ def handle_rlwinm(
     # resulting expression. If there is an `|`, the expression is best left as bitwise math
     simplify = simplify and not (left_mask and right_mask)
 
-    uw_source = early_unwrap(source)
-    if isinstance(uw_source, Literal):
-        upper_value = (uw_source.value << left_shift) & mask
-        lower_value = (uw_source.value >> right_shift) & mask
+    if isinstance(source, Literal):
+        upper_value = (source.value << left_shift) & mask
+        lower_value = (source.value >> right_shift) & mask
         return Literal(upper_value | lower_value)
 
     upper_bits: Optional[Expression]
@@ -3613,7 +3604,7 @@ def handle_rlwimi(
     mask_literal = Literal(rlwi_mask(mask_begin, mask_end))
     mask = UnaryOp("~", mask_literal, type=Type.u32())
     masked_base = BinaryOp.int(left=base, op="&", right=mask)
-    if early_unwrap(source) == Literal(0):
+    if source == Literal(0):
         # If the source is 0, there are no bits inserted. (This may look like `x &= ~0x10`)
         return masked_base
     # Set `simplify=False` to keep the `inserted` expression as bitwise math instead of `*` or `/`

--- a/src/translate.py
+++ b/src/translate.py
@@ -651,7 +651,6 @@ def escape_byte(b: int) -> bytes:
 class Var:
     stack_info: StackInfo = field(repr=False)
     prefix: str
-    num_usages: int = 0
     name: Optional[str] = None
 
     def format(self, fmt: Formatter) -> str:
@@ -3921,8 +3920,8 @@ class NodeState:
         *,
         emit_exactly_once: bool,
         trivial: bool,
-        prefix: str = "",
-        reuse_var: Optional[Var] = None,
+        prefix: str,
+        # reuse_var: Optional[Var] = None,
     ) -> EvalOnceExpr:
         if emit_exactly_once:
             # (otherwise this will be marked used once num_usages reaches 1)
@@ -3932,9 +3931,10 @@ class NodeState:
             # so they're less likely to appear in the output
             return expr
 
-        if reuse_var is not None:
-            var = reuse_var
-        else:
+        # if reuse_var is not None:
+        #     var = reuse_var
+        # else:
+        if True:
             assert prefix
             if prefix == "condition_bit":
                 prefix = "cond"
@@ -3950,7 +3950,6 @@ class NodeState:
             emit_exactly_once=emit_exactly_once,
             trivial=trivial,
         )
-        var.num_usages += 1
         stmt = EvalOnceStmt(expr)
         self.write_statement(stmt)
         self.stack_info.temp_vars.append(stmt)
@@ -3965,6 +3964,7 @@ class NodeState:
                 # Mark the register as "if used, emit the expression's once
                 # var". We usually always have a once var at this point,
                 # but if we don't, create one.
+                # TODO
                 if not isinstance(expr, EvalOnceExpr):
                     expr = self._eval_once(
                         expr,
@@ -4052,6 +4052,7 @@ class NodeState:
                     expr = orig_expr
 
         uw_expr = expr
+        # TODO
         if not isinstance(expr, Literal):
             expr = self._eval_once(
                 expr,
@@ -4391,6 +4392,8 @@ def translate_graph_from_block(
             r for r in locs_clobbered_until_dominator(child) if isinstance(r, Register)
         )
         for reg in phi_regs:
+            # sources = ...
+            # if sources is not None:
             if reg_always_set(child, reg, dom_set=(reg in state.regs)):
                 expr: Optional[Expression] = stack_info.maybe_get_register_var(reg)
                 if expr is None:

--- a/src/translate.py
+++ b/src/translate.py
@@ -2389,6 +2389,15 @@ def simplify_condition(expr: Expression) -> Expression:
     return expr
 
 
+def condition_from_expr(expr: Expression) -> Condition:
+    uw_expr = early_unwrap(expr)
+    if isinstance(uw_expr, Condition) and not (
+        isinstance(uw_expr, BinaryOp) and not uw_expr.is_comparison()
+    ):
+        return uw_expr
+    return ExprCondition(expr, type=expr.type)
+
+
 def balanced_parentheses(string: str) -> bool:
     """
     Check if parentheses in a string are balanced, ignoring any non-parenthesis

--- a/src/translate.py
+++ b/src/translate.py
@@ -2311,6 +2311,7 @@ def is_trivial_expression(expr: Expression) -> bool:
             PassedInArg,
             PhiExpr,
             RegisterVar,
+            SecondF64Half,
             SubroutineArg,
         ),
     ):
@@ -4260,14 +4261,12 @@ class NodeState:
         for out in outputs:
             if not isinstance(out, Register):
                 continue
-            val = return_reg_vals[out]
-            if not isinstance(val, SecondF64Half):
-                val = self._eval_once(
-                    val,
-                    emit_exactly_once=False,
-                    trivial=False,
-                    prefix=self._format_reg(out),
-                )
+            val = self._eval_once(
+                return_reg_vals[out],
+                emit_exactly_once=False,
+                trivial=False,
+                prefix=self._format_reg(out),
+            )
             self.set_reg_without_eval(out, val, function_return=True)
 
         self.has_function_call = True

--- a/tests/end_to_end/arg-temp/test-out.c
+++ b/tests/end_to_end/arg-temp/test-out.c
@@ -1,0 +1,7 @@
+s32 test(s32 arg0) {
+    s32 temp_a0;
+
+    temp_a0 = arg0;
+    arg0 = 0;
+    return temp_a0;
+}

--- a/tests/end_to_end/arg-temp/test.s
+++ b/tests/end_to_end/arg-temp/test.s
@@ -1,0 +1,5 @@
+glabel test
+sw $zero, ($sp)
+move $v0, $a0
+jr $ra
+nop


### PR DESCRIPTION
Use EvalOnce wrappers for:
- initial registers (arguments, sp, gp, etc.)
- SecondF64Half
- floating point comparisons
- literals

and statically type-check that RegInfo.contents contains only EvalOnceExpr, RegisterVar, and PhiExpr. (Of which the latter two will probably eventually be merged.) Add RegMeta.initial to replace PassedInArg.copied (not strictly necessary but the wrappers got in the way of checking for "copied" and it seemed a nice cleanup).

This is in preparation for the phi refactoring I'm working on.

OOT project diff is approximately empty, haven't checked other projects.