### PR TITLE
Add Pascal support

### DIFF
--- a/src/arch_mips.py
+++ b/src/arch_mips.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 from .error import DecompFailure
-from .options import Target
+from .options import ArchEnum
 from .asm_file import Label
 from .asm_instruction import (
     Argument,
@@ -678,7 +678,7 @@ class GpJumpPattern(SimpleAsmPattern):
 
 
 class MipsArch(Arch):
-    arch = Target.ArchEnum.MIPS
+    arch = ArchEnum.MIPS
 
     stack_pointer_reg = Register("sp")
     frame_pointer_reg = Register("fp")

--- a/src/arch_ppc.py
+++ b/src/arch_ppc.py
@@ -14,7 +14,7 @@ from typing import (
 from .error import DecompFailure
 from .flow_graph import FlowGraph
 from .ir_pattern import IrMatch, IrPattern
-from .options import Target
+from .options import ArchEnum
 from .asm_instruction import (
     Argument,
     AsmAddressMode,
@@ -331,7 +331,7 @@ class UintToFloatIrPattern(IrPattern, CheckConstantMixin):
 
 
 class PpcArch(Arch):
-    arch = Target.ArchEnum.PPC
+    arch = ArchEnum.PPC
 
     stack_pointer_reg = Register("r1")
     frame_pointer_reg = Register("r30")

--- a/src/flow_graph.py
+++ b/src/flow_graph.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 from .error import DecompFailure, static_assert_unreachable
-from .options import Formatter, Options, Target
+from .options import ArchEnum, Formatter, Options
 from .asm_file import AsmData, Function, Label
 from .asm_instruction import (
     AsmAddressMode,
@@ -370,7 +370,7 @@ def simplify_standard_patterns(function: Function, arch: ArchFlowGraph) -> Funct
 def build_blocks(
     function: Function, asm_data: AsmData, arch: ArchFlowGraph, *, fragment: bool
 ) -> List[Block]:
-    if arch.arch == Target.ArchEnum.MIPS:
+    if arch.arch == ArchEnum.MIPS:
         verify_no_trailing_delay_slot(function)
         function = normalize_likely_branches(function, arch)
 
@@ -538,7 +538,7 @@ def build_blocks(
             block_builder.new_block()
 
     for item in body_iter:
-        if arch.arch == Target.ArchEnum.MIPS:
+        if arch.arch == ArchEnum.MIPS:
             process_mips(item)
         else:
             process_no_delay_slots(item)

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1469,9 +1469,12 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
             arg_strs.append(arg.type.to_decl(arg.format(fmt), fmt))
     if function_info.stack_info.is_variadic:
         arg_strs.append("...")
-    arg_str = ", ".join(arg_strs)
-    if not arg_str and fmt.language != Language.PASCAL:
-        arg_str = "void"
+    if fmt.language == Language.PASCAL:
+        arg_str = "; ".join(arg_strs)
+    else:
+        arg_str = ", ".join(arg_strs)
+        if not arg_str:
+            arg_str = "void"
 
     fn_header = f"{fn_name}({arg_str})"
 

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -11,7 +11,7 @@ from .flow_graph import (
     SwitchNode,
     TerminalNode,
 )
-from .options import Options, Target
+from .options import Compiler, Options
 from .translate import (
     BinaryOp,
     BlockInfo,
@@ -851,7 +851,7 @@ def try_build_irregular_switch(
                     node_queue.append((node.fallthrough_edge, bounds.without(val)))
                 elif cond.op == "!=" and (
                     node.block.index > node.conditional_edge.block.index
-                    or context.options.target.compiler != Target.CompilerEnum.IDO
+                    or context.options.target.compiler != Compiler.IDO
                 ):
                     if val in cases:
                         return None
@@ -893,7 +893,7 @@ def try_build_irregular_switch(
             continue
 
         values = bounds.values(max_count=1)
-        if values and context.options.target.compiler != Target.CompilerEnum.IDO:
+        if values and context.options.target.compiler != Compiler.IDO:
             # The bounds only have a few possible values, so add this node to the set of cases
             # IDO won't make implicit cases like this, however.
             for value in values:
@@ -1444,7 +1444,7 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
         local_vars = function_info.stack_info.local_vars
         # GCC's stack is ordered low-to-high (e.g. `int sp10; int sp14;`)
         # IDO's and MWCC's stack is ordered high-to-low (e.g. `int sp14; int sp10;`)
-        if options.target.compiler != Target.CompilerEnum.GCC:
+        if options.target.compiler != Compiler.GCC:
             local_vars = local_vars[::-1]
         for local_var in local_vars:
             type_decl = local_var.toplevel_decl(fmt)

--- a/src/if_statements.py
+++ b/src/if_statements.py
@@ -1102,6 +1102,7 @@ def build_switch_statement(
     The nodes must already be labeled with `add_labels_for_switch` before calling this.
     """
     switch_body = Body(print_node_comment=context.options.debug)
+    break_text = None if context.fmt.language == Language.PASCAL else "break;"
 
     # If there are any case labels to jump to the `end` node immediately after the
     # switch block, emit them as `case ...: break;` at the start of the switch block
@@ -1116,7 +1117,7 @@ def build_switch_statement(
         else:
             remaining_labels.append((index, case_label))
     if len(remaining_labels) != len(context.case_nodes[end]):
-        switch_body.add_statement(SimpleStatement(f"break;", is_jump=True))
+        switch_body.add_statement(SimpleStatement(break_text, is_jump=True))
         context.case_nodes[end] = remaining_labels
 
     # Order case blocks by their position in the asm, not by their order in the jump table
@@ -1142,7 +1143,7 @@ def build_switch_statement(
         else:
             switch_body.extend(build_flowgraph_between(context, case, end))
             if not switch_body.ends_in_jump():
-                switch_body.add_statement(SimpleStatement("break;", is_jump=True))
+                switch_body.add_statement(SimpleStatement(break_text, is_jump=True))
     return SwitchStatement(jump, switch_body, switch_index)
 
 

--- a/src/instruction.py
+++ b/src/instruction.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, replace
 from typing import Callable, Dict, Iterator, List, Optional, Union
 
 from .error import DecompFailure
-from .options import Target
+from .options import ArchEnum
 from .asm_instruction import (
     ArchAsmParsing,
     Argument,
@@ -157,7 +157,7 @@ class Instruction:
 class ArchAsm(ArchAsmParsing):
     """Arch-specific information that relates to the asm level. Extends ArchAsmParsing."""
 
-    arch: Target.ArchEnum
+    arch: ArchEnum
 
     stack_pointer_reg: Register
     frame_pointer_reg: Optional[Register]

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from .c_types import TypeMap, build_typemap, dump_typemap
 from .error import DecompFailure
 from .flow_graph import FlowGraph, build_flowgraph, visualize_flowgraph
 from .if_statements import get_function_text
-from .options import CodingStyle, Options, Target
+from .options import ArchEnum, CodingStyle, Options, Target
 from .asm_file import AsmData, Function, parse_file
 from .instruction import InstrProcessingFailure
 from .translate import (
@@ -65,9 +65,9 @@ def print_exception_as_comment(
 
 def run(options: Options) -> int:
     arch: Arch
-    if options.target.arch == Target.ArchEnum.MIPS:
+    if options.target.arch == ArchEnum.MIPS:
         arch = MipsArch()
-    elif options.target.arch == Target.ArchEnum.PPC:
+    elif options.target.arch == ArchEnum.PPC:
         arch = PpcArch()
     else:
         raise ValueError(f"Invalid target arch: {options.target.arch}")

--- a/src/main.py
+++ b/src/main.py
@@ -454,7 +454,7 @@ def parse_flags(flags: List[str]) -> Options:
         type=Target.parse,
         default="mips-ido-c",
         help="Target architecture, compiler, and language triple. "
-        "Supported triples: mips-ido-c, mips-gcc-c, mipsel-gcc-c, ppc-mwcc-c++, ppc-mwcc-c. "
+        "Supported triples: mips-ido-c, mips-ido-pascal, mips-gcc-c, mipsel-gcc-c, ppc-mwcc-c++, ppc-mwcc-c. "
         "Default is mips-ido-c, `ppc` is an alias for ppc-mwcc-c++. ",
     )
     group.add_argument(

--- a/src/options.py
+++ b/src/options.py
@@ -251,7 +251,9 @@ class Formatter:
     def format_int(self, val: int, size_bits: Optional[int] = None) -> str:
         if abs(val) < 10:
             return str(val)
+        return self.format_int_hex(val, size_bits)
 
+    def format_int_hex(self, val: int, size_bits: Optional[int] = None) -> str:
         if self.zfill_constants and size_bits is not None:
             hex_digits = f"{abs(val):0{size_bits // 4}X}"
         else:

--- a/src/options.py
+++ b/src/options.py
@@ -247,7 +247,8 @@ class Formatter:
         return format(val, "x").upper()
 
     def format_int(self, val: int, size_bits: Optional[int] = None) -> str:
-        if abs(val) < 10:
+        hex_cap = 256 if self.language == Language.PASCAL else 10
+        if abs(val) < hex_cap:
             return str(val)
         return self.format_int_hex(val, size_bits)
 

--- a/src/options.py
+++ b/src/options.py
@@ -30,32 +30,36 @@ class CodingStyle:
     comment_column: int
 
 
+class ArchEnum(ChoicesEnum):
+    MIPS = "mips"
+    PPC = "ppc"
+
+
+class Endian(ChoicesEnum):
+    LITTLE = "little"
+    BIG = "big"
+
+
+class Compiler(ChoicesEnum):
+    IDO = "ido"
+    GCC = "gcc"
+    MWCC = "mwcc"
+
+
+class Language(ChoicesEnum):
+    C = "c"
+    CXX = "c++"
+
+
 @dataclass
 class Target:
-    class ArchEnum(ChoicesEnum):
-        MIPS = "mips"
-        PPC = "ppc"
-
-    class EndianEnum(ChoicesEnum):
-        LITTLE = "little"
-        BIG = "big"
-
-    class CompilerEnum(ChoicesEnum):
-        IDO = "ido"
-        GCC = "gcc"
-        MWCC = "mwcc"
-
-    class LanguageEnum(ChoicesEnum):
-        C = "c"
-        CXX = "c++"
-
     arch: ArchEnum
-    endian: EndianEnum
-    compiler: CompilerEnum
-    language: LanguageEnum
+    endian: Endian
+    compiler: Compiler
+    language: Language
 
     def is_big_endian(self) -> bool:
-        return self.endian == Target.EndianEnum.BIG
+        return self.endian == Endian.BIG
 
     @staticmethod
     def parse(name: str) -> "Target":
@@ -65,27 +69,27 @@ class Target:
         If `-compiler` is missing, use the default for the arch.
         (This makes `mips` an alias for `mips-ido-c`, etc.)
         """
-        endian = Target.EndianEnum.BIG
+        endian = Endian.BIG
         terms = name.split("-")
         try:
             arch_name = terms[0]
             if arch_name.endswith("el"):
                 arch_name = arch_name[:-2]
-                endian = Target.EndianEnum.LITTLE
-            arch = Target.ArchEnum(arch_name)
+                endian = Endian.LITTLE
+            arch = ArchEnum(arch_name)
             if len(terms) >= 2:
-                compiler = Target.CompilerEnum(terms[1])
-            elif arch == Target.ArchEnum.PPC:
-                compiler = Target.CompilerEnum.MWCC
+                compiler = Compiler(terms[1])
+            elif arch == ArchEnum.PPC:
+                compiler = Compiler.MWCC
             else:
-                compiler = Target.CompilerEnum.IDO
+                compiler = Compiler.IDO
 
             if len(terms) >= 3:
-                language = Target.LanguageEnum(terms[2])
-            elif compiler == Target.CompilerEnum.MWCC:
-                language = Target.LanguageEnum.CXX
+                language = Language(terms[2])
+            elif compiler == Compiler.MWCC:
+                language = Language.CXX
             else:
-                language = Target.LanguageEnum.C
+                language = Language.C
         except ValueError as e:
             raise ValueError(f"Unable to parse Target '{name}' ({e})")
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -1156,7 +1156,7 @@ class UnaryOp(Condition):
 
         op = self.op
         if fmt.language == Language.PASCAL:
-            op = {"!": "not"}.get(op, op)
+            op = {"!": "not "}.get(op, op)
         return f"{op}{self.expr.format(fmt)}"
 
 
@@ -1679,6 +1679,8 @@ class AddressOf(Expression):
             ref = self.expr.make_reference()
             if ref:
                 return f"{ref.format(fmt)}"
+        if fmt.language == Language.PASCAL:
+            return f"addr({format_expr(self.expr, fmt)})"
         return f"&{self.expr.format(fmt)}"
 
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -1105,6 +1105,8 @@ class BinaryOp(Condition):
             if fn_op:
                 return f"{fn_op}({lhs}, {rhs})"
             op = {"==": "=", "!=": "<>", "&&": "and", "||": "or"}.get(op, op)
+            if op == "/" and not self.is_floating():
+                op = "div"
 
         return f"({lhs} {op} {rhs})"
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -41,7 +41,7 @@ from .flow_graph import (
     locs_clobbered_until_dominator,
 )
 from .ir_pattern import IrPattern, simplify_ir_patterns
-from .options import CodingStyle, Formatter, Options, Target
+from .options import ArchEnum, CodingStyle, Formatter, Language, Options, Target
 from .asm_file import AsmData, AsmDataEntry
 from .asm_instruction import (
     Argument,
@@ -270,7 +270,7 @@ class StackInfo:
         return prefix + (f"_{counter}" if counter > 1 else "")
 
     def in_subroutine_arg_region(self, location: int) -> bool:
-        if self.global_info.arch.arch == Target.ArchEnum.PPC:
+        if self.global_info.arch.arch == ArchEnum.PPC:
             return False
         if self.is_leaf:
             return False
@@ -282,7 +282,7 @@ class StackInfo:
             return True
         # PPC saves LR in the header of the previous stack frame
         if (
-            self.global_info.arch.arch == Target.ArchEnum.PPC
+            self.global_info.arch.arch == ArchEnum.PPC
             and location == self.allocated_stack_size + 4
         ):
             return True
@@ -2326,7 +2326,7 @@ class InstrArgs:
         ret = self.regs[reg]
 
         # PPC: FPR's hold doubles (64 bits), so we don't need to do anything special
-        if self.stack_info.global_info.arch.arch == Target.ArchEnum.PPC:
+        if self.stack_info.global_info.arch.arch == ArchEnum.PPC:
             return ret
 
         # MIPS: Look at the paired FPR to get the full 64-bit value
@@ -3422,7 +3422,7 @@ class NodeState:
             # We don't do this stricter filtering for variadic functions, though, since
             # those don't provide "fix the context" as a way out if we get it wrong.
             if (
-                arch.arch == Target.ArchEnum.PPC
+                arch.arch == ArchEnum.PPC
                 and not fn_sig.is_variadic
                 and (data.meta.inherited or data.meta.function_return)
                 and not self._reg_probably_meant_as_function_argument(reg, call_instr)
@@ -3805,7 +3805,7 @@ class GlobalInfo:
         else:
             demangled_symbol: Optional[CxxSymbol] = None
             demangled_str: Optional[str] = None
-            if self.target.language == Target.LanguageEnum.CXX:
+            if self.target.language == Language.CXX:
                 try:
                     demangled_symbol = demangle_codewarrior_parse(sym_name)
                 except ValueError:
@@ -3822,7 +3822,7 @@ class GlobalInfo:
 
             # If the symbol is a C++ vtable, try to build a custom type for it by parsing it
             if (
-                self.target.language == Target.LanguageEnum.CXX
+                self.target.language == Language.CXX
                 and sym_name.startswith("__vt__")
                 and sym.asm_data_entry is not None
             ):
@@ -4140,7 +4140,7 @@ class GlobalInfo:
                 # In modes except "all", skip vtable decls when compiling C++
                 if (
                     decls != Options.GlobalDeclsEnum.ALL
-                    and self.target.language == Target.LanguageEnum.CXX
+                    and self.target.language == Language.CXX
                     and name.startswith("__vt__")
                 ):
                     continue

--- a/src/translate.py
+++ b/src/translate.py
@@ -1624,7 +1624,16 @@ class Literal(Expression):
         suffix = ""
         if not fmt.skip_casts and not self.elide_cast:
             if self.type.is_pointer():
-                prefix = f"({self.type.format(fmt)})"
+                return (
+                    Cast(
+                        Literal(self.value, type=Type.intish()),
+                        type=self.type,
+                        reinterpret=True,
+                        silent=False,
+                    )
+                    .format(fmt)
+                    .replace(") ", ")")
+                )
             if self.type.is_unsigned() and fmt.language != Language.PASCAL:
                 suffix = "U"
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -1245,10 +1245,12 @@ class Cast(Expression):
         if fmt.skip_casts:
             return self.expr.format(fmt)
 
+        if fmt.language == Language.PASCAL:
+            return f"{self.type.format(fmt)}({self.expr.format(fmt)})"
+
         # Function casts require special logic because function calls have
         # higher precedence than casts
-        fn_sig = self.type.get_function_pointer_signature()
-        if fn_sig:
+        if self.type.get_function_pointer_signature():
             return f"(({self.type.format(fmt)}) {self.expr.format(fmt)})"
 
         return f"({self.type.format(fmt)}) {self.expr.format(fmt)}"

--- a/src/types.py
+++ b/src/types.py
@@ -1164,10 +1164,11 @@ def format_pascal_type(type: CType) -> str:
     if isinstance(type, ca.ArrayDecl):
         dims = "?"
         if type.dim is not None:
-            upper_bound: "ca.Expression" = ca.BinaryOp("-", type.dim, ca.ID("1"))
-            if isinstance(type.dim, ca.ID):
+            const = lambda v: ca.Constant("", str(v))
+            upper_bound: "ca.Expression" = ca.BinaryOp("-", type.dim, const(1))
+            if isinstance(type.dim, ca.Constant):
                 try:
-                    upper_bound = ca.ID(str(int(type.dim.name, 0) - 1))
+                    upper_bound = const(int(type.dim.value, 0) - 1)
                 except ValueError:
                     pass
             dims = f"0..{to_c(upper_bound)}"

--- a/src/types.py
+++ b/src/types.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
 import pycparser.c_ast as ca
 
@@ -1164,7 +1164,7 @@ def format_pascal_type(type: CType) -> str:
     if isinstance(type, ca.ArrayDecl):
         dims = "?"
         if type.dim is not None:
-            const = lambda v: ca.Constant("", str(v))
+            const: Callable[[int], "ca.Expression"] = lambda v: ca.Constant("", str(v))
             upper_bound: "ca.Expression" = ca.BinaryOp("-", type.dim, const(1))
             if isinstance(type.dim, ca.Constant):
                 try:

--- a/src/types.py
+++ b/src/types.py
@@ -1426,8 +1426,9 @@ class StructDeclaration:
 
             def offset_comment(offset: int) -> str:
                 # Indicate the offset of the field (in hex), written to the *left* of the field
-                nonlocal offset_str_digits
-                return f"/* 0x{fmt.format_hex(offset).zfill(offset_str_digits)} */"
+                return fmt.multiline_comment(
+                    f"0x{fmt.format_hex(offset).zfill(offset_str_digits)}"
+                )
 
             position = 0
             prev_field: Optional[StructDeclaration.StructField] = None


### PR DESCRIPTION
This PR allows converting linguistically aberrant compiler subsystems (as1, perhaps?) back into Pascal.

Practically speaking, I don't think this is actually worth merging: it adds too much clutter and maintenance effort for such a niche use-case. I think we can leave it around as a long-lived branch instead. But I wanted to make a PR out of it to make it easy to see the diff.