### PR TITLE
Fix negative values for hex cases

### DIFF
--- a/m2c/if_statements.py
+++ b/m2c/if_statements.py
@@ -440,7 +440,10 @@ def add_labels_for_switch(
         if enum_name:
             case_label = f"case {enum_name}"
         elif use_hex:
-            case_label = f"case 0x{index:X}"
+            if index < 0:
+                case_label = f"case -0x{-index:X}"
+            else:
+                case_label = f"case 0x{index:X}"
         else:
             case_label = f"case {index}"
 


### PR DESCRIPTION
Negative hex cases produce an invalid value like this:
```c
        switch (temp_v1) {                          /* switch 3; irregular */
            case 0x-1:                              /* switch 3 */
```
With this fix a proper negative value is emitted:
```c
        switch (temp_v1) {                          /* switch 3; irregular */
            case -0x1:                              /* switch 3 */
```
