### PR TITLE
`--disable-qualifiers-hints` flag

### DIFF
--- a/m2c/main.py
+++ b/m2c/main.py
@@ -429,6 +429,12 @@ def parse_flags(flags: List[str]) -> Options:
         help="Column number to justify comments to. Set to 0 to disable justification. Default: 52",
     )
     group.add_argument(
+        "--disable-qualifiers-hints",
+        dest="disable_qualifiers_hints",
+        action="store_true",
+        help="Turns off qualifiers hints for functions and data",
+    )
+    group.add_argument(
         "--no-casts",
         dest="skip_casts",
         action="store_true",
@@ -577,6 +583,7 @@ def parse_flags(flags: List[str]) -> Options:
         hex_case=args.hex_case,
         comment_style=args.comment_style,
         comment_column=args.comment_column,
+        disable_qualifiers_hints=args.disable_qualifiers_hints,
     )
 
     functions: List[Union[int, str]] = []

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -429,8 +429,8 @@ def parse_flags(flags: List[str]) -> Options:
         help="Column number to justify comments to. Set to 0 to disable justification. Default: 52",
     )
     group.add_argument(
-        "--disable-qualifiers-hints",
-        dest="disable_qualifiers_hints",
+        "--no-qualifiers-hints",
+        dest="no_qualifiers_hints",
         action="store_true",
         help="Turns off qualifiers hints for functions and variables. externs qualifiers for data are not disabled by this flag",
     )
@@ -583,7 +583,7 @@ def parse_flags(flags: List[str]) -> Options:
         hex_case=args.hex_case,
         comment_style=args.comment_style,
         comment_column=args.comment_column,
-        disable_qualifiers_hints=args.disable_qualifiers_hints,
+        no_qualifiers_hints=args.no_qualifiers_hints,
     )
 
     functions: List[Union[int, str]] = []

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -432,7 +432,7 @@ def parse_flags(flags: List[str]) -> Options:
         "--disable-qualifiers-hints",
         dest="disable_qualifiers_hints",
         action="store_true",
-        help="Turns off qualifiers hints for functions and data",
+        help="Turns off qualifiers hints for functions and variables. externs qualifiers for data are not disabled by this flag",
     )
     group.add_argument(
         "--no-casts",

--- a/m2c/options.py
+++ b/m2c/options.py
@@ -28,7 +28,7 @@ class CodingStyle:
     hex_case: bool
     comment_style: CommentStyle
     comment_column: int
-    disable_qualifiers_hints: bool
+    no_qualifiers_hints: bool
 
 
 @dataclass
@@ -162,7 +162,7 @@ DEFAULT_CODING_STYLE: CodingStyle = CodingStyle(
     hex_case=False,
     comment_style=CodingStyle.CommentStyle.MULTILINE,
     comment_column=52,
-    disable_qualifiers_hints=False,
+    no_qualifiers_hints=False,
 )
 
 

--- a/m2c/options.py
+++ b/m2c/options.py
@@ -28,6 +28,7 @@ class CodingStyle:
     hex_case: bool
     comment_style: CommentStyle
     comment_column: int
+    disable_qualifiers_hints: bool
 
 
 @dataclass
@@ -161,6 +162,7 @@ DEFAULT_CODING_STYLE: CodingStyle = CodingStyle(
     hex_case=False,
     comment_style=CodingStyle.CommentStyle.MULTILINE,
     comment_column=52,
+    disable_qualifiers_hints=False,
 )
 
 

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -4113,15 +4113,16 @@ class GlobalInfo:
                 comments = []
 
                 # Determine type qualifier: static, extern, or neither
-                if (is_in_file and is_global) or fmt.coding_style.disable_qualifiers_hints:
-                    qualifier = ""
-                elif is_in_file:
-                    qualifier = "static"
-                else:
+                if not is_in_file:
                     qualifier = "extern"
+                elif is_in_file and is_global:
+                    qualifier = ""
+                elif not fmt.coding_style.disable_qualifiers_hints:
+                    qualifier = "static"
 
                 if sym.type.is_function():
-                    comments.append(qualifier)
+                    if not fmt.coding_style.disable_qualifiers_hints:
+                        comments.append(qualifier)
                     qualifier = ""
 
                 # Try to guess if the symbol is an array (and if it is, its dimension) if

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -4113,7 +4113,7 @@ class GlobalInfo:
                 comments = []
 
                 # Determine type qualifier: static, extern, or neither
-                if is_in_file and is_global:
+                if (is_in_file and is_global) or fmt.coding_style.disable_qualifiers_hints:
                     qualifier = ""
                 elif is_in_file:
                     qualifier = "static"

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -4117,11 +4117,11 @@ class GlobalInfo:
                     qualifier = "extern"
                 elif is_in_file and is_global:
                     qualifier = ""
-                elif not fmt.coding_style.disable_qualifiers_hints:
+                elif not fmt.coding_style.no_qualifiers_hints:
                     qualifier = "static"
 
                 if sym.type.is_function():
-                    if not fmt.coding_style.disable_qualifiers_hints:
+                    if not fmt.coding_style.no_qualifiers_hints:
                         comments.append(qualifier)
                     qualifier = ""
 


### PR DESCRIPTION
Adds a flag to disable the `static` and `extern` qualifiers hints from functions and variables.

`extern` for variables is being special cased because not using it means migrating the variable with may not be desired.

Quick diff for this flag:
```diff
diff --git a/asdf.c b/asdf.c
index b88df7b..2a6c759 100644
--- a/asdf.c
+++ b/asdf.c
@@ -1,45 +1,31 @@
-? PlaySE(? *, ?, s32, s32);                         /* extern */
-s32 func_80001E98_usa(s32, s8 *, s32, s32);         /* extern */
-? func_80002FD0_usa(s32, s16, ?, ?);                /* extern */
-? func_80035504_usa(s32 *);                         /* extern */
-s32 func_800544D4_usa(s32);                         /* extern */
-? func_80058DF0_usa(?, ?, s32, s32);                /* extern */
-? func_8005DD3C_usa(s8 *);                          /* extern */
-? func_8005DDB4_usa(s8 *);                          /* extern */
-? func_8005DDF8_usa(s8 *);                          /* extern */
-? func_8006B628_usa(s8 *);                          /* extern */
-? func_8006B6A8_usa(s8 *);                          /* extern */
-? func_8006B730_usa(s8 *);                          /* extern */
-void func_80035B20_usa(void *arg0, s32 arg1, s32 arg2); /* static */
-void func_80035FF0_usa(void *arg0, s32 arg1, s32 arg2); /* static */
-void func_800364BC_usa();                           /* static */
-void func_800364FC_usa();                           /* static */
-void func_80036A68_usa();                           /* static */
-void func_8003722C_usa();                           /* static */
+? PlaySE(? *, ?, s32, s32);
+s32 func_80001E98_usa(s32, s8 *, s32, s32);
+? func_80002FD0_usa(s32, s16, ?, ?);
+? func_80035504_usa(s32 *);
+s32 func_800544D4_usa(s32);
+? func_80058DF0_usa(?, ?, s32, s32);
+? func_8005DD3C_usa(s8 *);
+? func_8005DDB4_usa(s8 *);
+? func_8005DDF8_usa(s8 *);
+? func_8006B628_usa(s8 *);
+? func_8006B6A8_usa(s8 *);
+? func_8006B730_usa(s8 *);
+void func_80035B20_usa(void *arg0, s32 arg1, s32 arg2);
+void func_80035FF0_usa(void *arg0, s32 arg1, s32 arg2);
+void func_800364BC_usa();
+void func_800364FC_usa();
+void func_80036A68_usa();
+void func_8003722C_usa();
 extern s32 B_8019CF98_usa;
 extern ? D_0101F378_usa;
 extern ? D_01023A68_usa;
 extern ? D_01023C68_usa;
 extern ? D_800B3AFC_usa;
 extern s32 last_song_handle;
-static ? D_800B3B11;                                /* unable to generate initializer */
-static ? D_800B3B15;                                /* unable to generate initializer */
-static ? D_800B3B34_usa;                            /* unable to generate initializer */
-static ? D_800B3B38_usa;                            /* unable to generate initializer */
-static ? D_800B3F04_usa;                            /* unable to generate initializer */
-static ? D_800B3F0C_usa;                            /* unable to generate initializer */
-static ? D_800B3F0E_usa;                            /* unable to generate initializer */
-static ? D_800B3F10_usa;                            /* unable to generate initializer */
-static ? D_800B3F12_usa;                            /* unable to generate initializer */
-static ? D_800B3F14_usa;                            /* unable to generate initializer */
-static ? D_800B3F20_usa;                            /* unable to generate initializer */
-static ? D_800B3F54_usa;                            /* unable to generate initializer */
-static ? D_800B3F88_usa;                            /* unable to generate initializer */
-static ? D_800B3F9C_usa;                            /* unable to generate initializer */
-static ? BGM_INIT_TABLE;                            /* unable to generate initializer */
-static ? SFX_INIT_TABLE;                            /* unable to generate initializer */
 f32 D_FLT_800B3B10_usa;                             /* unable to generate initializer */
+? D_800B3B11;                                       /* unable to generate initializer */
 f32 D_FLT_800B3B14_usa;                             /* unable to generate initializer */
+? D_800B3B15;                                       /* unable to generate initializer */
 u8 D_800B3B18_usa = 2;
 s16 DangerMusicBgmIndex = 1;
 s16 NormalMusicBgmIndex = 0;
@@ -51,6 +37,20 @@ s16 ts_ok_start_timer = 1;
 s16 ts_timer_counter = 0;
 s16 ts_current_alert = 0;
 s16 ts_old_alert = -1;
+? D_800B3B34_usa;                                   /* unable to generate initializer */
+? D_800B3B38_usa;                                   /* unable to generate initializer */
+? D_800B3F04_usa;                                   /* unable to generate initializer */
+? D_800B3F0C_usa;                                   /* unable to generate initializer */
+? D_800B3F0E_usa;                                   /* unable to generate initializer */
+? D_800B3F10_usa;                                   /* unable to generate initializer */
+? D_800B3F12_usa;                                   /* unable to generate initializer */
+? D_800B3F14_usa;                                   /* unable to generate initializer */
+? D_800B3F20_usa;                                   /* unable to generate initializer */
+? D_800B3F54_usa;                                   /* unable to generate initializer */
+? D_800B3F88_usa;                                   /* unable to generate initializer */
+? D_800B3F9C_usa;                                   /* unable to generate initializer */
+? BGM_INIT_TABLE;                                   /* unable to generate initializer */
+? SFX_INIT_TABLE;                                   /* unable to generate initializer */
 
 /*
 Decompilation failure in function func_8004B300_usa:
```

I noted some variables ended up being reordered, I haven't investigated further, but my guess is m2c is ordering the variables alphabetically and it was considering the `static` as part of the name.