### PR TITLE
Fix `M2C_ERROR` when the message contains a comma

### DIFF
--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -818,7 +818,7 @@ class ErrorExpr(Condition):
 
     def format(self, fmt: Formatter) -> str:
         if self.desc is not None:
-            return f"M2C_ERROR({self.desc})"
+            return f"M2C_ERROR(/* {self.desc} */)"
         return "M2C_ERROR()"
 
 

--- a/m2c_macros.h
+++ b/m2c_macros.h
@@ -28,7 +28,7 @@ typedef s64 M2C_UNK64;
 #define M2C_UNALIGNED32(expr) (expr)
 
 /* Unhandled instructions */
-#define M2C_ERROR(desc) (0)
+#define M2C_ERROR(...) (0)
 #define M2C_TRAP_IF(cond) (0)
 #define M2C_BREAK() (0)
 #define M2C_SYNC() (0)

--- a/m2c_macros.h
+++ b/m2c_macros.h
@@ -28,7 +28,7 @@ typedef s64 M2C_UNK64;
 #define M2C_UNALIGNED32(expr) (expr)
 
 /* Unhandled instructions */
-#define M2C_ERROR(...) (0)
+#define M2C_ERROR(desc) (0)
 #define M2C_TRAP_IF(cond) (0)
 #define M2C_BREAK() (0)
 #define M2C_SYNC() (0)

--- a/tests/end_to_end/error/manual-out.c
+++ b/tests/end_to_end/error/manual-out.c
@@ -16,9 +16,9 @@
     M2C_TRAP_IF((u32) arg0 < 4U);
     M2C_TRAP_IF(arg0 >= 5);
     M2C_TRAP_IF((u32) arg0 >= 6U);
-    M2C_ERROR(unknown instruction: badinstr $t0, $t0);
-    temp_t1 = M2C_ERROR(unknown instruction: badinstr2 $t1, $t1);
+    M2C_ERROR(/* unknown instruction: badinstr $t0, $t0 */);
+    temp_t1 = M2C_ERROR(/* unknown instruction: badinstr2 $t1, $t1 */);
     *NULL = temp_t1 << temp_t1;
-    *NULL = (s32) (M2C_ERROR(Read from unset register $v1) + 2);
-    return M2C_ERROR(unknown instruction: badinstr3 $v0, $t2);
+    *NULL = (s32) (M2C_ERROR(/* Read from unset register $v1 */) + 2);
+    return M2C_ERROR(/* unknown instruction: badinstr3 $v0, $t2 */);
 }

--- a/tests/end_to_end/ps2/manual-out.c
+++ b/tests/end_to_end/ps2/manual-out.c
@@ -4,8 +4,8 @@ void test(s32 arg2, s32 arg3) {
     ? sp4;
     s32 temp_a2;
 
-    M2C_ERROR(unknown instruction: sq $ra, 0x20($sp));
+    M2C_ERROR(/* unknown instruction: sq $ra, 0x20($sp) */);
     temp_a2 = arg2 * 2;
     foo(sp, &sp4, temp_a2, arg3 + (temp_a2 * 2));
-    M2C_ERROR(unknown instruction: lq $ra, 0x20($sp));
+    M2C_ERROR(/* unknown instruction: lq $ra, 0x20($sp) */);
 }


### PR DESCRIPTION
Uses a variadic macro to ensure valid C syntax.

An alternative approach would be to emit either strings or comments within the macro, rather than unescaped C.