### PR TITLE
Add K&R brace style option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The following options control the formatting details of the output, such as brac
 
 - `--valid-syntax`
 - `--allman` ("Allman braces")
+- `--knr` ("K&R braces")
 - `--pointer-style` ("`*` to the left")
 - `--unk-underscore`
 - `--hex-case`

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -373,11 +373,18 @@ def parse_flags(flags: List[str]) -> Options:
         help="Emit valid C syntax, using macros to indicate unknown types or other "
         "unusual statements. Macro definitions are in `m2c_macros.h`.",
     )
-    group.add_argument(
+    brace_style = group.add_mutually_exclusive_group()
+    brace_style.add_argument(
         "--allman",
         dest="allman",
         action="store_true",
         help="Put braces on separate lines",
+    )
+    brace_style.add_argument(
+        "--knr",
+        dest="knr",
+        action="store_true",
+        help="Put function opening braces on separate lines",
     )
     group.add_argument(
         "--indent-switch-contents",
@@ -567,7 +574,7 @@ def parse_flags(flags: List[str]) -> Options:
         preproc_defines[parts[0]] = int(parts[1], 0) if len(parts) >= 2 else 1
 
     coding_style = CodingStyle(
-        newline_after_function=args.allman,
+        newline_after_function=args.allman or args.knr,
         newline_after_if=args.allman,
         newline_before_else=args.allman,
         switch_indent_level=2 if args.indent_switch_contents else 1,

--- a/website.py
+++ b/website.py
@@ -40,6 +40,8 @@ if "source" in form:
         cmd.append("--no-casts")
     if "allman" in form:
         cmd.append("--allman")
+    if "knr" in form:
+        cmd.append("--knr")
     if "extraswitchindent" in form:
         cmd.append("--indent-switch-contents")
     if "leftptr" in form:
@@ -265,6 +267,7 @@ label {
     <label><input type="checkbox" name="noandor">Disable &amp;&amp;/||</label>
     <label><input type="checkbox" name="nocasts">Hide type casts</label>
     <label><input type="checkbox" name="allman">Allman braces</label>
+    <label><input type="checkbox" name="knr">K&R braces</label>
     <label><input type="checkbox" name="extraswitchindent">Indent switch contents an extra level</label>
     <label><input type="checkbox" name="leftptr">* to the left</label>
     <label><input type="checkbox" name="zfillconstants">0-fill constants</label>
@@ -353,7 +356,7 @@ contextEl.addEventListener("change", function() {
     localStorage.mips_to_c_saved_context = contextEl.value;
 });
 document.getElementById("options").addEventListener("change", function(event) {
-    var shouldSave = ["usesidebar", "allman", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs"];
+    var shouldSave = ["usesidebar", "allman", "knr", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs"];
     var options = {};
     for (var key of shouldSave) {
         var el = document.getElementsByName(key)[0];


### PR DESCRIPTION
doldecomp/melee puts function opening braces on their own lines (and no other braces). https://en.wikipedia.org/wiki/Indentation_style#K&R_style

This command-line option is mutually exclusive with the `--allman` option.