### PR TITLE
Fix ppc store update instructions

### DIFF
--- a/m2c/arch_ppc.py
+++ b/m2c/arch_ppc.py
@@ -776,9 +776,7 @@ class PpcArch(Arch):
                     # Update the register in the second argument
                     update = a.reg_ref(1)
                     offset = a.reg(2)
-                    s.set_reg(
-                        update, add_imm(update, a.regs[update], offset, a)
-                    )
+                    s.set_reg(update, add_imm(update, a.regs[update], offset, a))
 
                     if store is not None:
                         s.store_memory(store, a.reg_ref(0))
@@ -799,7 +797,9 @@ class PpcArch(Arch):
                         )
                     s.set_reg(
                         update.rhs,
-                        add_imm(update.rhs, a.regs[update.rhs], Literal(update.offset), a),
+                        add_imm(
+                            update.rhs, a.regs[update.rhs], Literal(update.offset), a
+                        ),
                     )
 
                     if store is not None:


### PR DESCRIPTION
Currently, indexed store update instructions give an error along the lines of
```c
        // Error: Expected instruction argument to be of the form offset($register), but found $r3
        // At instruction: stwux $r9, $r3, $r5
```
due to the call of `a.memory_ref` in the eval_fn (which is only valid for the non-indexed versions).

This PR fixes this by splitting out the eval_fn into separate ones for the indexed and non-indexed versions like load update instructions do

One thing that's worth noting is that none of the current tests contain any of these instructions, and #187 doesn't actually list them; Super Paper Mario has some functions using the instructions if that helps (possibly means that only later CW versions actually emitted them)