### PR TITLE
Add `.L` local label compatibility

### DIFF
--- a/m2c/asm_file.py
+++ b/m2c/asm_file.py
@@ -337,7 +337,7 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
     re_comment_or_string = re.compile(r'[#;].*|/\*.*?\*/|"(?:\\.|[^\\"])*"')
     re_whitespace_or_string = re.compile(r'\s+|"(?:\\.|[^\\"])*"')
     re_local_glabel = re.compile("L(_.*_)?[0-9A-F]{8}")
-    re_local_label = re.compile("loc_|locret_|def_|lbl_|LAB_|jump_")
+    re_local_label = re.compile("loc_|locret_|def_|lbl_|LAB_|jump_|.L")
     re_label = re.compile(r'(?:([a-zA-Z0-9_.$]+)|"([a-zA-Z0-9_.$<>@,-]+)"):')
 
     T = TypeVar("T")


### PR DESCRIPTION
Some decompilation projects are using conventions such as `.L_80112818` for local labels. This should allow decomp.me to understand them.