### PR TITLE
Add support for PS2's `paddub` and `sq`/`lq` instructions

### DIFF
--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -159,6 +159,7 @@ LENGTH_THREE: Set[str] = {
     "divu",
     "ddiv",
     "ddivu",
+    "paddub",
 }
 
 
@@ -881,6 +882,8 @@ class MipsArch(Arch):
                 return AsmInstruction("not", [args[0], args[1]])
             if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
                 return AsmInstruction("move", args[:2])
+            if instr.mnemonic == "paddub" and args[2] == AsmLiteral(0):
+                return AsmInstruction("move", args[:2])
             if (
                 instr.mnemonic == "ori"
                 and args[1] == Register("zero")
@@ -1494,6 +1497,7 @@ class MipsArch(Arch):
         "addiu": lambda a: handle_addi(a),
         "add": lambda a: handle_add(a),
         "addu": lambda a: handle_add(a),
+        "paddub": lambda a: handle_add(a),
         "sub": lambda a: (
             fold_mul_chains(fold_divmod(BinaryOp.intptr(a.reg(1), "-", a.reg(2))))
         ),

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -961,7 +961,7 @@ class MipsArch(Arch):
                 if loc is None:
                     return []
                 elif size == 16:
-                    return [loc, replace(loc, offset=loc.offset + 8)]
+                    return [loc, replace(loc, offset=loc.offset + 4), replace(loc, offset=loc.offset + 8), replace(loc, offset=loc.offset + 12)] 
                 elif size == 8:
                     return [loc, replace(loc, offset=loc.offset + 4)]
                 else:

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -882,7 +882,7 @@ class MipsArch(Arch):
                 return AsmInstruction("not", [args[0], args[1]])
             if instr.mnemonic == "addiu" and args[2] == AsmLiteral(0):
                 return AsmInstruction("move", args[:2])
-            if instr.mnemonic == "paddub" and args[2] == AsmLiteral(0):
+            if instr.mnemonic == "paddub" and args[2] == Register("zero"):
                 return AsmInstruction("move", args[:2])
             if (
                 instr.mnemonic == "ori"

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -1312,6 +1312,7 @@ class MipsArch(Arch):
         "sh": lambda a: make_store(a, type=Type.int_of_size(16)),
         "sw": lambda a: make_store(a, type=Type.reg32(likely_float=False)),
         "sd": lambda a: make_store(a, type=Type.reg64(likely_float=False)),
+        "sq": lambda a: make_store(a, type=Type.reg128(likely_float=False)),
         # Unaligned stores
         "swl": lambda a: handle_swl(a),
         "swr": lambda a: handle_swr(a),
@@ -1648,6 +1649,7 @@ class MipsArch(Arch):
         "lhu": lambda a: handle_load(a, type=Type.u16()),
         "lw": lambda a: handle_lw(a),
         "ld": lambda a: handle_load(a, type=Type.reg64(likely_float=False)),
+        "lq": lambda a: handle_load(a, type=Type.reg128(likely_float=False)),
         "lwu": lambda a: handle_load(a, type=Type.u32()),
         "lwc1": lambda a: handle_load(a, type=Type.reg32(likely_float=True)),
         "ldc1": lambda a: handle_load(a, type=Type.reg64(likely_float=True)),

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -961,7 +961,12 @@ class MipsArch(Arch):
                 if loc is None:
                     return []
                 elif size == 16:
-                    return [loc, replace(loc, offset=loc.offset + 4), replace(loc, offset=loc.offset + 8), replace(loc, offset=loc.offset + 12)] 
+                    return [
+                        loc,
+                        replace(loc, offset=loc.offset + 4),
+                        replace(loc, offset=loc.offset + 8),
+                        replace(loc, offset=loc.offset + 12),
+                    ]
                 elif size == 8:
                     return [loc, replace(loc, offset=loc.offset + 4)]
                 else:

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -159,7 +159,6 @@ LENGTH_THREE: Set[str] = {
     "divu",
     "ddiv",
     "ddivu",
-    "paddub",
 }
 
 
@@ -1315,7 +1314,7 @@ class MipsArch(Arch):
         "sh": lambda a: make_store(a, type=Type.int_of_size(16)),
         "sw": lambda a: make_store(a, type=Type.reg32(likely_float=False)),
         "sd": lambda a: make_store(a, type=Type.reg64(likely_float=False)),
-        "sq": lambda a: make_store(a, type=Type.reg128(likely_float=False)),
+        "sq": lambda a: make_store(a, type=Type.reg128()),
         # Unaligned stores
         "swl": lambda a: handle_swl(a),
         "swr": lambda a: handle_swr(a),
@@ -1501,7 +1500,6 @@ class MipsArch(Arch):
         "addiu": lambda a: handle_addi(a),
         "add": lambda a: handle_add(a),
         "addu": lambda a: handle_add(a),
-        "paddub": lambda a: handle_add(a),
         "sub": lambda a: (
             fold_mul_chains(fold_divmod(BinaryOp.intptr(a.reg(1), "-", a.reg(2))))
         ),
@@ -1652,7 +1650,7 @@ class MipsArch(Arch):
         "lhu": lambda a: handle_load(a, type=Type.u16()),
         "lw": lambda a: handle_lw(a),
         "ld": lambda a: handle_load(a, type=Type.reg64(likely_float=False)),
-        "lq": lambda a: handle_load(a, type=Type.reg128(likely_float=False)),
+        "lq": lambda a: handle_load(a, type=Type.reg128()),
         "lwu": lambda a: handle_load(a, type=Type.u32()),
         "lwc1": lambda a: handle_load(a, type=Type.reg32(likely_float=True)),
         "ldc1": lambda a: handle_load(a, type=Type.reg64(likely_float=True)),

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -951,6 +951,7 @@ class MipsArch(Arch):
             "h": 2,
             "w": 4,
             "d": 8,
+            "q": 16,
         }
         size = memory_sizes.get(mnemonic[1:2])
 
@@ -960,6 +961,8 @@ class MipsArch(Arch):
                 loc = StackLocation.from_offset(arg.lhs)
                 if loc is None:
                     return []
+                elif size == 16:
+                    return [loc, replace(loc, offset=loc.offset + 8)]
                 elif size == 8:
                     return [loc, replace(loc, offset=loc.offset + 4)]
                 else:

--- a/m2c/types.py
+++ b/m2c/types.py
@@ -928,6 +928,14 @@ class Type:
         return Type(TypeData(kind=TypeData.K_INT, size_bits=64))
 
     @staticmethod
+    def s128() -> Type:
+        return Type(TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.SIGNED))
+
+    @staticmethod
+    def u128() -> Type:
+        return Type(TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.UNSIGNED))
+
+    @staticmethod
     def int_of_size(size_bits: int) -> Type:
         return Type(TypeData(kind=TypeData.K_INT, size_bits=size_bits))
 
@@ -941,6 +949,12 @@ class Type:
         kind = TypeData.K_FLOAT | TypeData.K_INT
         likely = TypeData.K_FLOAT if likely_float else TypeData.K_INT
         return Type(TypeData(kind=kind, likely_kind=likely, size_bits=64))
+
+    @staticmethod
+    def reg128(*, likely_float: bool) -> Type:
+        kind = TypeData.K_FLOAT | TypeData.K_INT
+        likely = TypeData.K_FLOAT if likely_float else TypeData.K_INT
+        return Type(TypeData(kind=kind, likely_kind=likely, size_bits=128))
 
     @staticmethod
     def bool() -> Type:

--- a/m2c/types.py
+++ b/m2c/types.py
@@ -928,16 +928,6 @@ class Type:
         return Type(TypeData(kind=TypeData.K_INT, size_bits=64))
 
     @staticmethod
-    def s128() -> Type:
-        return Type(TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.SIGNED))
-
-    @staticmethod
-    def u128() -> Type:
-        return Type(
-            TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.UNSIGNED)
-        )
-
-    @staticmethod
     def int_of_size(size_bits: int) -> Type:
         return Type(TypeData(kind=TypeData.K_INT, size_bits=size_bits))
 
@@ -953,10 +943,8 @@ class Type:
         return Type(TypeData(kind=kind, likely_kind=likely, size_bits=64))
 
     @staticmethod
-    def reg128(*, likely_float: bool) -> Type:
-        kind = TypeData.K_FLOAT | TypeData.K_INT
-        likely = TypeData.K_FLOAT if likely_float else TypeData.K_INT
-        return Type(TypeData(kind=kind, likely_kind=likely, size_bits=128))
+    def reg128() -> Type:
+        return Type(TypeData(kind=TypeData.K_INT, size_bits=128))
 
     @staticmethod
     def bool() -> Type:

--- a/m2c/types.py
+++ b/m2c/types.py
@@ -933,7 +933,9 @@ class Type:
 
     @staticmethod
     def u128() -> Type:
-        return Type(TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.UNSIGNED))
+        return Type(
+            TypeData(kind=TypeData.K_INT, size_bits=128, sign=TypeData.UNSIGNED)
+        )
 
     @staticmethod
     def int_of_size(size_bits: int) -> Type:

--- a/tests/end_to_end/ps2/manual-out.c
+++ b/tests/end_to_end/ps2/manual-out.c
@@ -4,8 +4,6 @@ void test(s32 arg2, s32 arg3) {
     ? sp4;
     s32 temp_a2;
 
-    M2C_ERROR(/* unknown instruction: sq $ra, 0x20($sp) */);
     temp_a2 = arg2 * 2;
     foo(sp, &sp4, temp_a2, arg3 + (temp_a2 * 2));
-    M2C_ERROR(/* unknown instruction: lq $ra, 0x20($sp) */);
 }

--- a/tests/end_to_end/ps2/manual_mwcc-out.c
+++ b/tests/end_to_end/ps2/manual_mwcc-out.c
@@ -1,0 +1,7 @@
+? func2__FiPPc(s32, ?);                             /* extern */
+? func__Fv();                                       /* extern */
+
+void test(s32 arg0, ? arg1) {
+    func__Fv();
+    func2__FiPPc(arg0, arg1);
+}

--- a/tests/end_to_end/ps2/manual_mwcc.s
+++ b/tests/end_to_end/ps2/manual_mwcc.s
@@ -1,0 +1,16 @@
+glabel test
+addiu    $sp, $sp, -0x30
+sq       $ra, 0x20($sp)
+sq       $s1, 0x10($sp)
+sq       $s0, 0x00($sp)
+paddub   $s0, $a0, $zero
+jal      func__Fv
+ paddub  $s1, $a1, $zero
+paddub   $a0, $s0, $zero
+jal      func2__FiPPc
+ paddub  $a1, $s1, $zero
+lq       $s0, 0x00($sp)
+lq       $s1, 0x10($sp)
+lq       $ra, 0x20($sp)
+jr       $ra
+ addiu   $sp, $sp, -0x30


### PR DESCRIPTION
Compilers like MWCC 2.3 fairly commonly, and since they are kinda simple I thought it would be good to have them

- `paddub`: Behaves like `addu` but for quad registers. From what I have seen it is mostly used as a `move`
![image](https://github.com/matt-kempster/m2c/assets/7416381/94eb34f0-cb6c-4a57-9009-d9d118f0de09)
- `sq`/`lq`: Those behave like `sw` and `lw` but for quad registers. Most commonly used to save registers into the stack
![image](https://github.com/matt-kempster/m2c/assets/7416381/3509fde3-cc62-4c10-a189-1f7c3fc56a4a)
![image](https://github.com/matt-kempster/m2c/assets/7416381/dcfcbf4b-f6d8-4889-a046-acb58bf5cfa6)
