### PR TITLE
Add support for `seb`/`seh` instructions from mips32r2

### DIFF
--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -62,6 +62,7 @@ from .translate import (
     as_intish,
     as_s64,
     as_sintish,
+    as_type,
     as_u32,
     as_u64,
     as_uintish,
@@ -86,8 +87,6 @@ from .evaluate import (
     handle_lwl,
     handle_lwr,
     handle_or,
-    handle_seb,
-    handle_seh,
     handle_sltiu,
     handle_sltu,
     handle_sra,
@@ -1665,8 +1664,8 @@ class MipsArch(Arch):
         "lwl": lambda a: handle_lwl(a),
         "lwr": lambda a: handle_lwr(a),
         # Sign extend
-        "seb": lambda a: handle_seb(a),
-        "seh": lambda a: handle_seh(a),
+        "seb": lambda a: as_type(a.reg(1), Type.s8(), silent=False),
+        "seh": lambda a: as_type(a.reg(1), Type.s16(), silent=False),
     }
 
     @staticmethod

--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -86,6 +86,8 @@ from .evaluate import (
     handle_lwl,
     handle_lwr,
     handle_or,
+    handle_seb,
+    handle_seh,
     handle_sltiu,
     handle_sltu,
     handle_sra,
@@ -1662,6 +1664,9 @@ class MipsArch(Arch):
         # Unaligned loads
         "lwl": lambda a: handle_lwl(a),
         "lwr": lambda a: handle_lwr(a),
+        # Sign extend
+        "seb": lambda a: handle_seb(a),
+        "seh": lambda a: handle_seh(a),
     }
 
     @staticmethod

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -451,16 +451,6 @@ def handle_lwr(args: InstrArgs) -> Expression:
     return ErrorExpr("Unable to handle lwr; missing a corresponding lwl")
 
 
-def handle_seb(args: InstrArgs) -> Expression:
-    # Sign extend byte
-    return as_type(args.reg(1), Type.s8(), silent=False)
-
-
-def handle_seh(args: InstrArgs) -> Expression:
-    # Sign extend half-word
-    return as_type(args.reg(1), Type.s16(), silent=False)
-
-
 def make_store(args: InstrArgs, type: Type) -> Optional[StoreStmt]:
     size = type.get_size_bytes()
     assert size is not None

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -452,12 +452,12 @@ def handle_lwr(args: InstrArgs) -> Expression:
 
 
 def handle_seb(args: InstrArgs) -> Expression:
-    # Sign extend byte, it is a cast to s16
+    # Sign extend byte
     return as_type(args.reg(1), Type.s8(), silent=False)
 
 
 def handle_seh(args: InstrArgs) -> Expression:
-    # Sign extend half-word, it is a cast to s16
+    # Sign extend half-word
     return as_type(args.reg(1), Type.s16(), silent=False)
 
 

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -451,6 +451,16 @@ def handle_lwr(args: InstrArgs) -> Expression:
     return ErrorExpr("Unable to handle lwr; missing a corresponding lwl")
 
 
+def handle_seb(args: InstrArgs) -> Expression:
+    # Sign extend byte, it is a cast to s16
+    return as_type(args.reg(1), Type.s8(), silent=False)
+
+
+def handle_seh(args: InstrArgs) -> Expression:
+    # Sign extend half-word, it is a cast to s16
+    return as_type(args.reg(1), Type.s16(), silent=False)
+
+
 def make_store(args: InstrArgs, type: Type) -> Optional[StoreStmt]:
     size = type.get_size_bytes()
     assert size is not None

--- a/tests/end_to_end/seb-seh/seb-mwcc-out.c
+++ b/tests/end_to_end/seb-seh/seb-mwcc-out.c
@@ -1,0 +1,8 @@
+s8 foo(s8);                                         /* extern */
+
+s8 test(s32 arg0) {
+    s32 sp10;
+
+    sp10 = arg0;
+    return (s8) (foo((s8) sp10) + 1);
+}

--- a/tests/end_to_end/seb-seh/seb-mwcc.s
+++ b/tests/end_to_end/seb-seh/seb-mwcc.s
@@ -1,0 +1,19 @@
+glabel test
+addiu   sp,sp,-0x20
+sw      ra,0xc(sp)
+sw      s0,8(sp)
+sw      a0,0x10(sp)
+lw      v0,0x10(sp)
+seb     a0,v0
+jal     foo
+nop
+seb     v0,v0
+addiu   v0,v0,1
+seb     v0,v0
+seb     s0,v0
+move    v0,s0
+lw      ra,0xc(sp)
+lw      s0,8(sp)
+addiu   sp,sp,0x20
+jr      ra
+nop

--- a/tests/end_to_end/seb-seh/seh-mwcc-out.c
+++ b/tests/end_to_end/seb-seh/seh-mwcc-out.c
@@ -1,0 +1,8 @@
+s16 foo(s16);                                       /* extern */
+
+s16 test(s32 arg0) {
+    s32 sp10;
+
+    sp10 = arg0;
+    return (s16) (foo((s16) sp10) + 1);
+}

--- a/tests/end_to_end/seb-seh/seh-mwcc.s
+++ b/tests/end_to_end/seb-seh/seh-mwcc.s
@@ -1,0 +1,19 @@
+glabel test
+addiu   sp,sp,-0x20
+sw      ra,0xc(sp)
+sw      s0,8(sp)
+sw      a0,0x10(sp)
+lw      v0,0x10(sp)
+seh     a0,v0
+jal     foo
+nop
+seh     v0,v0
+addiu   v0,v0,1
+seh     v0,v0
+seh     s0,v0
+move    v0,s0
+lw      ra,0xc(sp)
+lw      s0,8(sp)
+addiu   sp,sp,0x20
+jr      ra
+nop


### PR DESCRIPTION
These instructions are found specifically on PlayStation Portable and they are backported to its processor from the mips32r2 specs.

`SEH` is a single instruction that replaces the combo `sll DST_REG, SRC_REG, 0x10` and `sra DST_REG, DST_REG, 0x10` to perform a `s16` cast. Same concept for `SEB` but when a cast to `s8` is required.

![SEB instruction](https://github.com/matt-kempster/m2c/assets/6128729/256e9555-f559-45c3-b453-50604e3f8b02)

![SEH instruction](https://github.com/matt-kempster/m2c/assets/6128729/a16f0187-ece1-45d8-b33f-a58e8dcd197b)
