### PR TITLE
pyproject.toml: Add `m2c` entrypoint when installed as package

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,29 @@ git add tests/end_to_end/my-new-test
 For PowerPC, the `MWCC_CC` environment variable should be set to point to a PPC cc binary (mwcceppc.exe),
 and on non-Windows, `WINE` set to point to wine or equivalent ([wibo](https://github.com/decompals/wibo) also works).
 
-### Installation with Poetry
+### Installation as Python Package
 
-You can include `m2c` as a dependency in your project with [Poetry](https://python-poetry.org/) by adding the following to your `pyproject.toml`:
+You can include `m2c` as a dependency in your project with [Poetry](https://python-poetry.org/)
+by adding the following to your `pyproject.toml`:
+
 ```toml
 [tool.poetry.dependencies]
 m2c = {git="https://github.com/matt-kempster/m2c.git"}
+```
+
+If your project does not use `pyproject.toml` for dependencies, you can add the following
+to your `requirements.txt` file instead:
+
+```
+m2c @ git+https://github.com/matt-kempster/m2c.git
+
+# To specify a specific Git ref, such as a commit, tag, or branch:
+m2c @ git+https://github.com/matt-kempster/m2c.git@[YOUR REF HERE]
+```
+
+When installed as a Python package, a standalone command entrypoint is provided
+which can run the CLI.
+
+```bash
+m2c [options] [-t <target>] [--context <context file>] [-f <function name>] <asmfile>...
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/matt-kempster/m2c"
 packages = [{include = "m2c"}]
 
+[tool.poetry.scripts]
+m2c = "m2c.main:main"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 pycparser = "^2.21"


### PR DESCRIPTION
Currently, downstream users have to invoke some kind of Python script directly in order to run the CLI. This requires them to either write their own `m2c.py` wrapper script to invoke `m2c.main:main`, or manually download the repository (usually as a Git submodule).

This PR adds a freestanding command entrypoint, `m2c`, which can be run to invoke the `m2c` CLI simply by installing the Python package. This should streamline usage and dependency management for downstream users who don't use `m2c` as a library.