### PR TITLE
Added compatibility for decomp-toolkit macros

### DIFF
--- a/m2c/asm_file.py
+++ b/m2c/asm_file.py
@@ -512,6 +512,13 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
                         # ".rel name, label" expands to ".4byte name + (label - name)"
                         assert len(args) == 2
                         emit_word(args[1])
+                    elif directive == ".obj":
+                        # dtk disassembler label format
+                        assert len(args) == 2
+                        kind = (
+                            LabelKind.LOCAL if args[1] == "local" else LabelKind.GLOBAL
+                        )
+                        process_label(args[0], kind=kind)
                     elif directive in (".short", ".half", ".2byte"):
                         for w in args:
                             ival = try_parse(lambda: parse_int(w)) & 0xFFFF
@@ -554,14 +561,6 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
                         data = parse_incbin(args, options, warnings)
                         if data is not None:
                             asm_file.new_data_bytes(data)
-                    elif directive == ".obj":  # decomp-toolkit label format
-                        parts = line.split()
-                        if len(parts) >= 3:
-                            try:
-                                kind = LabelKind[parts[2].upper()]
-                                process_label(parts[1].removesuffix(","), kind=kind)
-                            except KeyError:
-                                pass
 
         elif ifdef_level == 0:
             if directive == "jlabel":

--- a/m2c/flow_graph.py
+++ b/m2c/flow_graph.py
@@ -860,7 +860,7 @@ def build_graph_from_block(
                             and isinstance(arg.argument, AsmGlobalSymbol)
                             and any(
                                 arg.argument.symbol_name.startswith(prefix)
-                                for prefix in ("jtbl", "jpt_", "lbl_")
+                                for prefix in ("jtbl", "jpt_", "lbl_", "jumptable_")
                             )
                         ):
                             jtbl_names.add(arg.argument.symbol_name)
@@ -877,7 +877,7 @@ def build_graph_from_block(
                 raise DecompFailure(
                     f"Unable to determine jump table for {jump.mnemonic} instruction {jump.meta.loc_str()}.\n\n"
                     "There must be a read of a variable before the instruction\n"
-                    'which has a name starting with with "jtbl"/"jpt_"/"lbl_".'
+                    'which has a name starting with with "jtbl"/"jpt_"/"lbl_"/"jumptable_".'
                 )
 
             jtbl_name = list(jtbl_names)[0]


### PR DESCRIPTION
[encounter/decomp-toolkit](https://github.com/encounter/decomp-toolkit) outputs assembly files that are currently not fully compatible with m2c.
One problem is that labels have the format
```
.obj name, local
    .float 0
.endobj name
```
This makes m2c not detect any data, bss, rodata or jump table labels.
Another problem is that jump tables have the prefix "jumptable_".
Ultimately, strings use the type ".string".