### PR TITLE
Add options to sort bss backwards and local variables descending by register number

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ The following options control the formatting details of the output, such as brac
 - `--no-casts`
 - `--zfill-constants` ("0-fill constants")
 - `--deterministic-vars`
+- `--descending-regs`
+- `--backwards-bss`
 
 Note: `--valid-syntax` is used to produce output that is less human-readable, but is likely to directly compile without edits. This can be used to go directly from assembly to the permuter without human intervention.
 

--- a/m2c/if_statements.py
+++ b/m2c/if_statements.py
@@ -1467,7 +1467,10 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
                 type_decl = var.type.to_decl(var.format(fmt), fmt)
                 temp_decls.append(f"{type_decl};")
                 any_decl = True
-        for decl in sorted(temp_decls):
+
+        var_sort = (lambda d: d.split("_")[1]) if fmt.descending_regs else None
+
+        for decl in sorted(temp_decls, key=var_sort, reverse=fmt.descending_regs):
             function_lines.append(SimpleStatement(decl).format(fmt))
 
         for phi_var in function_info.stack_info.naive_phi_vars:

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -470,6 +470,18 @@ def parse_flags(flags: List[str]) -> Options:
         help="Name temp and phi vars after their location in the source asm, "
         "rather than using an incrementing suffix. Can help reduce diff size in tests.",
     )
+    group.add_argument(
+        "--descending-regs",
+        dest="descending_regs",
+        action="store_true",
+        help="Sort variables in descending order by register number",
+    )
+    group.add_argument(
+        "--backwards-bss",
+        dest="backwards_bss",
+        action="store_true",
+        help="Sort bss variables backwards compared to what's in the asm",
+    )
 
     group = parser.add_argument_group("Analysis Options")
     group.add_argument(
@@ -640,6 +652,8 @@ def parse_flags(flags: List[str]) -> Options:
         passes=args.passes,
         incbin_dirs=args.incbin_dirs,
         deterministic_vars=args.deterministic_vars,
+        descending_regs=args.descending_regs,
+        backwards_bss=args.backwards_bss,
         disable_gc=args.disable_gc,
     )
 

--- a/m2c/options.py
+++ b/m2c/options.py
@@ -164,6 +164,8 @@ class Options:
     passes: int
     incbin_dirs: List[Path]
     deterministic_vars: bool
+    descending_regs: bool
+    backwards_bss: bool
     disable_gc: bool
 
     def formatter(self) -> Formatter:
@@ -173,6 +175,8 @@ class Options:
             zfill_constants=self.zfill_constants,
             force_decimal=self.force_decimal,
             valid_syntax=self.valid_syntax,
+            descending_regs=self.descending_regs,
+            backwards_bss=self.backwards_bss,
         )
 
 
@@ -200,6 +204,8 @@ class Formatter:
     line_length: int = 80
     zfill_constants: bool = False
     force_decimal: bool = False
+    descending_regs: bool = False
+    backwards_bss: bool = False
 
     def indent(self, line: str, indent: int = 0) -> str:
         return self.indent_step * max(indent + self.extra_indent, 0) + line

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -4198,12 +4198,23 @@ class GlobalInfo:
                     # Skip externally-declared symbols that are defined in other files
                     continue
 
+                # Flip the bss order if the corresponding option is set
+                if data_entry:
+                    file, index = data_entry.sort_order
+                    data_entry_order = (
+                        (file, index * -1)
+                        if data_entry.is_bss and fmt.backwards_bss
+                        else (file, index)
+                    )
+                else:
+                    data_entry_order = ("", 0)
+
                 sort_order = (
                     not sym.type.is_function(),
                     is_in_file,
                     is_global if not is_in_file else False,
                     is_const,
-                    data_entry.sort_order if data_entry is not None else ("", 0),
+                    data_entry_order,
                     name,
                 )
                 qualifier = ""

--- a/website.py
+++ b/website.py
@@ -72,6 +72,10 @@ if "source" in form:
         cmd.append("--stack-structs")
     if "nostackspill" in form:
         cmd.append("--no-stack-spill")
+    if "descendingregs" in form:
+        cmd.append("--descending-regs")
+    if "backwardsbss" in form:
+        cmd.append("--backwards-bss")
 
     comment_style = form.getfirst("comment_style", "multiline")
     if "none" in comment_style:
@@ -282,6 +286,8 @@ label {
     <label><input type="checkbox" name="nounkinference">Disable unknown struct/type inference</label>
     <label><input type="checkbox" name="stackstructs">Stack struct templates</label>
     <label><input type="checkbox" name="nostackspill">Disable stack spilling detection</label>
+    <label><input type="checkbox" name="descendingregs">Sort variables in descending order</label>
+    <label><input type="checkbox" name="backwardsbss">Sort bss in descending order</label>
     <label><input type="checkbox" name="usesidebar">Output sidebar</label>
     <label><input type="checkbox" name="dark">Dark mode</label>
   </div>
@@ -363,7 +369,7 @@ contextEl.addEventListener("change", function() {
     localStorage.mips_to_c_saved_context = contextEl.value;
 });
 document.getElementById("options").addEventListener("change", function(event) {
-    var shouldSave = ["usesidebar", "allman", "knr", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs", "nostackspill"];
+    var shouldSave = ["usesidebar", "allman", "knr", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs", "nostackspill", "descendingregs", "backwardsbss"];
     var options = {};
     for (var key of shouldSave) {
         var el = document.getElementsByName(key)[0];

--- a/website.py
+++ b/website.py
@@ -70,6 +70,8 @@ if "source" in form:
         cmd.append("--no-unk-inference")
     if "stackstructs" in form:
         cmd.append("--stack-structs")
+    if "nostackspill" in form:
+        cmd.append("--no-stack-spill")
 
     comment_style = form.getfirst("comment_style", "multiline")
     if "none" in comment_style:
@@ -279,6 +281,7 @@ label {
     <label><input type="checkbox" name="noswitches">Disable irregular switch detection</label>
     <label><input type="checkbox" name="nounkinference">Disable unknown struct/type inference</label>
     <label><input type="checkbox" name="stackstructs">Stack struct templates</label>
+    <label><input type="checkbox" name="nostackspill">Disable stack spilling detection</label>
     <label><input type="checkbox" name="usesidebar">Output sidebar</label>
     <label><input type="checkbox" name="dark">Dark mode</label>
   </div>
@@ -360,7 +363,7 @@ contextEl.addEventListener("change", function() {
     localStorage.mips_to_c_saved_context = contextEl.value;
 });
 document.getElementById("options").addEventListener("change", function(event) {
-    var shouldSave = ["usesidebar", "allman", "knr", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs"];
+    var shouldSave = ["usesidebar", "allman", "knr", "extraswitchindent", "leftptr", "zfillconstants", "globals", "nocasts", "noandor", "noifs", "noswitches", "dark", "regvarsselect", "regvars", "comment_style", "target", "nounkinference", "stackstructs", "nostackspill"];
     var options = {};
     for (var key of shouldSave) {
         var el = document.getElementsByName(key)[0];


### PR DESCRIPTION
These greatly help when decompiling Mario Party 4