### PR TITLE
Add a special `#ifdef` for decomp.me convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,20 @@ python3 ./m2c.py --visualize=c --context ctx.c -f my_fn my_asm.s > my_fn_c.svg
 python3 ./m2c.py --visualize=asm --context ctx.c -f my_fn my_asm.s > my_fn_asm.svg
 ```
 
+### Preprocessing
+
+There currently is a psuedo-macro in lieu of a full preprocessor that allows for the conditional switching of code in a context file. This allows for both m2c and i.e. a compiler to use the same context file if both need to define i.e. structs or typedefs slightly differently.
+
+```c
+#ifdef M2C
+...
+#else
+...
+#endif
+```
+
+Any other macros besides `#ifdef M2C` currently will fail, and you also need the `#else` between `#ifdef M2C` and `#endif` for the pattern to match.
+
 ### Migrating from `mips_to_c.py`
 
 This tool was originally known as `mips_to_c`. As part of the rename, deprecated command line arguments were removed.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ python3 ./m2c.py --visualize=asm --context ctx.c -f my_fn my_asm.s > my_fn_asm.s
 
 ### Preprocessing
 
-There currently is a psuedo-macro in lieu of a full preprocessor that allows for the conditional switching of code in a context file. This allows for both m2c and i.e. a compiler to use the same context file if both need to define i.e. structs or typedefs slightly differently.
+There currently is a pseudo-macro in lieu of a full preprocessor that allows for the conditional switching of code in a context file. This allows for both m2c and e.g. a compiler to use the same context file if both need to define e.g. structs or typedefs slightly differently.
 
 ```c
 #ifdef M2C

--- a/m2c/c_types.py
+++ b/m2c/c_types.py
@@ -648,7 +648,7 @@ def strip_comments(text: str) -> str:
 
 def process_ifdef(text: str) -> str:
     pattern = re.compile(
-        r"^[ \t]*#ifdef[ \t]+M2CTX_DUAL\s+"
+        r"^[ \t]*#ifdef[ \t]+M2C\s+"
         r"(?P<ifdef_body>.*?)"
         r"^[ \t]*#else\s+"
         r".*?"

--- a/m2c/c_types.py
+++ b/m2c/c_types.py
@@ -646,6 +646,7 @@ def strip_comments(text: str) -> str:
     )
     return re.sub(pattern, replacer, text)
 
+
 def process_ifdef(text: str) -> str:
     pattern = re.compile(
         r"^[ \t]*#ifdef[ \t]+M2C\s+"
@@ -653,9 +654,10 @@ def process_ifdef(text: str) -> str:
         r"^[ \t]*#else\s+"
         r".*?"
         r"^[ \t]*#endif.*?$",
-        flags=re.DOTALL | re.MULTILINE
+        flags=re.DOTALL | re.MULTILINE,
     )
     return re.sub(pattern, lambda m: m.group("ifdef_body"), text)
+
 
 def strip_macro_defs(text: str) -> str:
     """Strip macro definitions from C source. m2c does not run the preprocessor,

--- a/m2c/c_types.py
+++ b/m2c/c_types.py
@@ -646,6 +646,16 @@ def strip_comments(text: str) -> str:
     )
     return re.sub(pattern, replacer, text)
 
+def process_ifdef(text: str) -> str:
+    pattern = re.compile(
+        r"^[ \t]*#ifdef[ \t]+M2CTX_DUAL\s+"
+        r"(?P<ifdef_body>.*?)"
+        r"^[ \t]*#else\s+"
+        r".*?"
+        r"^[ \t]*#endif.*?$",
+        flags=re.DOTALL | re.MULTILINE
+    )
+    return re.sub(pattern, lambda m: m.group("ifdef_body"), text)
 
 def strip_macro_defs(text: str) -> str:
     """Strip macro definitions from C source. m2c does not run the preprocessor,
@@ -740,6 +750,7 @@ def _build_typemap(source_paths: Tuple[Path, ...], use_cache: bool) -> TypeMap:
 
         source = add_builtin_typedefs(source)
         source = strip_comments(source)
+        source = process_ifdef(source)
         source = strip_macro_defs(source)
 
         ast, result_scope = parse_c(source, typemap.cparser_scope)


### PR DESCRIPTION
This addresses a longstanding issue particularly affecting users trying to match Melee code on the m2c + decomp.me setup, where it's desirable to have the same context file able to both provide the correct type to m2c for the `user_data` of our custom `*_GObj` structs, as well as typedef the `*_GObj` structs back to `HSD_GObj`. Since it's undesirable to run a C preprocessor in m2c, a regular expression is used that mimics the functionality of an `#ifdef`, but only specific expressions are allowed to be used with it. Currently the only expression supported is hardcoded to be `M2CTX_DUAL`. Use of any other expression will raise a `Directives not supported yet` error like it currently does. The `#ifdef` also must contain an `#else` clause. For instance:

```c
#ifdef M2CTX_DUAL
typedef struct Fighter_GObj Fighter_GObj;
struct Fighter_GObj {
    /* +2C */ Fighter* user_data;
};
#else
typedef struct HSD_GObj Fighter_GObj;
#endif
```

If this kind of functionality is acceptable, I can write documentation for it, as other games may find this useful as well. 