### PR TITLE
Compat with new labels used by splat

### DIFF
--- a/m2c/asm_file.py
+++ b/m2c/asm_file.py
@@ -781,7 +781,7 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
                 "endlabel",
                 "enddlabel",
                 "alabel",
-                "nmlabel",
+                "nonmatching",
             ):
                 pass
 


### PR DESCRIPTION
Simply ignore the new label macros introduced by a future splat version https://github.com/ethteck/splat/pull/466 , since those aren't really meaningful to m2c.


