### PR TITLE
ARM: Fix subroutines getting appended with '/* extra? */' and 'Unable to find stack arg <offset> in block' for >= 4 args.

### DIFF
--- a/m2c/arch_arm.py
+++ b/m2c/arch_arm.py
@@ -1907,7 +1907,8 @@ class ArmArch(Arch):
                     if i < 4:
                         reg2 = Register(f"r{i}")
                     else:
-                        stack_loc = 4 * i
+                        # First stack parameter is at offset 0x00, so start at index (i - 4), which is 0.
+                        stack_loc = (i - 4) * 4
                     if size > 4:
                         name2 = f"{name}_unk{unk_offset:X}" if name else None
                         sub_type = Type.any()

--- a/m2c/arch_arm.py
+++ b/m2c/arch_arm.py
@@ -1907,7 +1907,6 @@ class ArmArch(Arch):
                     if i < 4:
                         reg2 = Register(f"r{i}")
                     else:
-                        # First stack parameter is at offset 0x00, so start at index (i - 4), which is 0.
                         stack_loc = (i - 4) * 4
                     if size > 4:
                         name2 = f"{name}_unk{unk_offset:X}" if name else None

--- a/m2c/c_types.py
+++ b/m2c/c_types.py
@@ -367,6 +367,8 @@ def parse_constant_int(expr: "ca.Expression", typemap: TypeMap) -> int:
         return parse_constant_int(expr.exprs[-1], typemap)
     if isinstance(expr, ca.UnaryOp) and not isinstance(expr.expr, ca.Typename):
         sub = parse_constant_int(expr.expr, typemap)
+        if expr.op == "+":
+            return sub
         if expr.op == "-":
             return -sub
         if expr.op == "~":

--- a/m2c/c_types.py
+++ b/m2c/c_types.py
@@ -484,7 +484,7 @@ def parse_struct_member(
 def do_parse_struct(struct: Union[ca.Struct, ca.Union], typemap: TypeMap) -> Struct:
     is_union = isinstance(struct, ca.Union)
     assert struct.decls is not None, "enforced by caller"
-    assert struct.decls, "Empty structs are not valid C"
+    assert struct.decls, f"{struct.name}: Empty structs are not valid C"
 
     fields: Dict[int, List[StructField]] = defaultdict(list)
     bitfields: Dict[int, List[BitField]] = defaultdict(list)


### PR DESCRIPTION
I'm not sure whether this could break in some other place, but it seems like the correct behavior to me.