### PR TITLE
Fix MSVC-mangled symbol parsing in PPC assembly

### DIFF
--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -234,44 +234,14 @@ class AsmState:
     is_unified: bool = False
 
 
-valid_word = string.ascii_letters + string.digits + "_$.?"
+valid_word = string.ascii_letters + string.digits + "_$."
 valid_number = "-xX" + string.hexdigits
 
 
 def parse_word(elems: List[str], valid: str = valid_word) -> str:
-    """Parse a word token, with special handling for MSVC-mangled symbols.
-
-    MSVC-mangled C++ symbols (starting with '?') may contain '@' characters
-    that must be distinguished from PPC relocation suffixes (@h, @ha, @l, etc.).
-    """
     ret: str = ""
-    # MSVC-mangled symbols start with '?' and can contain '@' as part of the name
-    is_msvc = elems and elems[0] == "?"
-
-    while elems:
-        ch = elems[0]
-        if ch in valid:
-            ret += elems.pop(0)
-        elif ch == "@" and is_msvc:
-            # Check if this '@' starts a relocation suffix or is part of the symbol
-            # Look ahead at what follows the '@'
-            lookahead = "".join(elems[1:21])  # Peek at next 20 chars
-            is_reloc = False
-            # Check for relocation suffixes (longest first to avoid partial matches)
-            for suffix in ("sda21", "sda2", "ha", "h", "l"):
-                if lookahead.startswith(suffix):
-                    # Verify suffix ends at operand boundary
-                    remaining = lookahead[len(suffix):]
-                    if not remaining or remaining[0] not in valid + "@":
-                        is_reloc = True
-                        break
-            if is_reloc:
-                # This '@' is a relocation marker; stop here
-                break
-            # This '@' is part of the MSVC symbol name; include it
-            ret += elems.pop(0)
-        else:
-            break
+    while elems and elems[0] in valid:
+        ret += elems.pop(0)
     return ret
 
 

--- a/tests/end_to_end/msvc-symbols/mwcc-o4p-flags.txt
+++ b/tests/end_to_end/msvc-symbols/mwcc-o4p-flags.txt
@@ -1,0 +1,1 @@
+--target ppc-mwcc-c

--- a/tests/end_to_end/msvc-symbols/mwcc-o4p-out.c
+++ b/tests/end_to_end/msvc-symbols/mwcc-o4p-out.c
@@ -1,0 +1,6 @@
+extern s32 ?TheDebug@@3VDebug@@A;
+static s32 normalSymbol;
+
+s32 test(void) {
+    return ?TheDebug@@3VDebug@@A + normalSymbol;
+}

--- a/tests/end_to_end/msvc-symbols/mwcc-o4p.s
+++ b/tests/end_to_end/msvc-symbols/mwcc-o4p.s
@@ -1,0 +1,28 @@
+.include "macros.inc"
+
+.section .text
+
+# Test MSVC-mangled C++ symbols with PPC relocation suffixes.
+# MSVC symbols start with ? and contain @ characters that must be
+# distinguished from @ha/@l/@h/@sda2/@sda21 relocation markers.
+
+.global test
+test:
+/* 00000000 00000000  3D 60 00 00 */	lis r11, ?TheDebug@@3VDebug@@A@ha
+/* 00000004 00000004  3D 40 00 00 */	lis r10, normalSymbol@ha
+/* 00000008 00000008  39 6B 00 00 */	addi r11, r11, ?TheDebug@@3VDebug@@A@l
+/* 0000000C 0000000C  39 4A 00 00 */	addi r10, r10, normalSymbol@l
+/* 00000010 00000010  80 6B 00 00 */	lwz r3, 0(r11)
+/* 00000014 00000014  80 0A 00 00 */	lwz r0, 0(r10)
+/* 00000018 00000018  7C 63 02 14 */	add r3, r3, r0
+/* 0000001C 0000001C  4E 80 00 20 */	blr
+
+.section .bss
+
+.global ?TheDebug@@3VDebug@@A
+?TheDebug@@3VDebug@@A:
+	.word 0x00000000
+
+.global normalSymbol
+normalSymbol:
+	.word 0x00000000

--- a/tests/unit/test_msvc_symbols.py
+++ b/tests/unit/test_msvc_symbols.py
@@ -1,4 +1,8 @@
-"""Tests for MSVC-mangled symbol parsing in PPC assembly."""
+"""Tests for MSVC-mangled symbol parsing in PPC assembly.
+
+The approach uses preprocessing to auto-quote MSVC symbols before they reach
+the generic parser, rather than modifying the parser itself.
+"""
 
 import unittest
 
@@ -8,126 +12,105 @@ from m2c.asm_instruction import (
     Macro,
     NaiveParsingArch,
     parse_arg_elems,
-    parse_word,
-    valid_word,
 )
+from m2c.instruction import _normalize_msvc_symbols
 
 
-class TestParseWordMsvcSymbols(unittest.TestCase):
-    """Test parse_word() with MSVC-mangled symbols."""
+class TestNormalizeMsvcSymbols(unittest.TestCase):
+    """Test the _normalize_msvc_symbols() preprocessing function."""
 
-    def test_simple_msvc_symbol(self) -> None:
-        """MSVC symbol without relocation."""
-        elems = list("?foo@@bar")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@@bar")
-        self.assertEqual(elems, [])
+    def test_simple_msvc_symbol_with_ha(self) -> None:
+        """MSVC symbol with @ha relocation gets quoted."""
+        result = _normalize_msvc_symbols("?TheDebug@@3VDebug@@A@ha")
+        self.assertEqual(result, '"?TheDebug@@3VDebug@@A"@ha')
 
-    def test_msvc_symbol_with_ha_reloc(self) -> None:
-        """MSVC symbol ending with @ha relocation."""
-        elems = list("?TheDebug@@3VDebug@@A@ha")
-        result = parse_word(elems)
-        self.assertEqual(result, "?TheDebug@@3VDebug@@A")
-        self.assertEqual(elems, list("@ha"))
+    def test_simple_msvc_symbol_with_l(self) -> None:
+        """MSVC symbol with @l relocation gets quoted."""
+        result = _normalize_msvc_symbols("?TheDebug@@3VDebug@@A@l")
+        self.assertEqual(result, '"?TheDebug@@3VDebug@@A"@l')
 
-    def test_msvc_symbol_with_l_reloc(self) -> None:
-        """MSVC symbol ending with @l relocation."""
-        elems = list("?TheDebug@@3VDebug@@A@l")
-        result = parse_word(elems)
-        self.assertEqual(result, "?TheDebug@@3VDebug@@A")
-        self.assertEqual(elems, list("@l"))
+    def test_simple_msvc_symbol_with_h(self) -> None:
+        """MSVC symbol with @h relocation gets quoted."""
+        result = _normalize_msvc_symbols("?foo@h")
+        self.assertEqual(result, '"?foo"@h')
 
-    def test_msvc_symbol_with_h_reloc(self) -> None:
-        """MSVC symbol ending with @h relocation."""
-        elems = list("?foo@h")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo")
-        self.assertEqual(elems, list("@h"))
+    def test_simple_msvc_symbol_with_sda21(self) -> None:
+        """MSVC symbol with @sda21 relocation gets quoted."""
+        result = _normalize_msvc_symbols("?foo@@bar@sda21")
+        self.assertEqual(result, '"?foo@@bar"@sda21')
 
-    def test_msvc_symbol_with_sda21_reloc(self) -> None:
-        """MSVC symbol ending with @sda21 relocation."""
-        elems = list("?foo@@bar@sda21")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@@bar")
-        self.assertEqual(elems, list("@sda21"))
-
-    def test_msvc_symbol_with_sda2_reloc(self) -> None:
-        """MSVC symbol ending with @sda2 relocation."""
-        elems = list("?foo@@bar@sda2")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@@bar")
-        self.assertEqual(elems, list("@sda2"))
+    def test_simple_msvc_symbol_with_sda2(self) -> None:
+        """MSVC symbol with @sda2 relocation gets quoted."""
+        result = _normalize_msvc_symbols("?foo@@bar@sda2")
+        self.assertEqual(result, '"?foo@@bar"@sda2')
 
     def test_msvc_double_at_before_ha_reloc(self) -> None:
         """MSVC symbol with @@ right before @ha relocation."""
-        elems = list("?foo@@ha")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@")
-        self.assertEqual(elems, list("@ha"))
+        result = _normalize_msvc_symbols("?foo@@ha")
+        self.assertEqual(result, '"?foo@"@ha')
 
     def test_msvc_at_not_reloc_followed_by_letters(self) -> None:
-        """@ha followed by more letters is NOT a relocation."""
-        elems = list("?foo@habla")
-        result = parse_word(elems)
+        """@ha followed by more letters is NOT a relocation - no quoting."""
+        result = _normalize_msvc_symbols("?foo@habla")
         self.assertEqual(result, "?foo@habla")
-        self.assertEqual(elems, [])
 
     def test_msvc_sda21_not_reloc_followed_by_letters(self) -> None:
-        """@sda21 followed by more letters is NOT a relocation."""
-        elems = list("?foo@sda21extra")
-        result = parse_word(elems)
+        """@sda21 followed by more letters is NOT a relocation - no quoting."""
+        result = _normalize_msvc_symbols("?foo@sda21extra")
         self.assertEqual(result, "?foo@sda21extra")
-        self.assertEqual(elems, [])
 
     def test_msvc_at_in_middle_then_reloc(self) -> None:
         """@h in middle of symbol, @l as relocation."""
-        elems = list("?foo@h@l")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@h")
-        self.assertEqual(elems, list("@l"))
+        result = _normalize_msvc_symbols("?foo@h@l")
+        self.assertEqual(result, '"?foo@h"@l')
 
     def test_msvc_complex_real_symbol(self) -> None:
         """Real-world MSVC symbol from dc3-decomp."""
-        elems = list("?ReadEndian@BinStream@@QAAXPAXH@Z@ha")
-        result = parse_word(elems)
-        self.assertEqual(result, "?ReadEndian@BinStream@@QAAXPAXH@Z")
-        self.assertEqual(elems, list("@ha"))
+        result = _normalize_msvc_symbols("?ReadEndian@BinStream@@QAAXPAXH@Z@ha")
+        self.assertEqual(result, '"?ReadEndian@BinStream@@QAAXPAXH@Z"@ha')
 
-    def test_msvc_symbol_with_trailing_comma(self) -> None:
-        """MSVC symbol followed by comma (operand separator)."""
-        elems = list("?foo@@bar@ha,")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@@bar")
-        self.assertEqual(elems, list("@ha,"))
+    def test_full_instruction_lis(self) -> None:
+        """Full lis instruction with MSVC symbol."""
+        result = _normalize_msvc_symbols("lis r11, ?TheDebug@@3VDebug@@A@ha")
+        self.assertEqual(result, 'lis r11, "?TheDebug@@3VDebug@@A"@ha')
 
-    def test_msvc_symbol_with_trailing_paren(self) -> None:
-        """MSVC symbol in parentheses."""
-        elems = list("?foo@@bar@l)")
-        result = parse_word(elems)
-        self.assertEqual(result, "?foo@@bar")
-        self.assertEqual(elems, list("@l)"))
+    def test_full_instruction_addi(self) -> None:
+        """Full addi instruction with MSVC symbol."""
+        result = _normalize_msvc_symbols("addi r29, r11, ?TheDebug@@3VDebug@@A@l")
+        self.assertEqual(result, 'addi r29, r11, "?TheDebug@@3VDebug@@A"@l')
 
     def test_non_msvc_symbol_unchanged(self) -> None:
-        """Regular symbol without ? should work as before."""
-        elems = list("normalSymbol@ha")
-        result = parse_word(elems)
-        self.assertEqual(result, "normalSymbol")
-        self.assertEqual(elems, list("@ha"))
+        """Regular symbol without ? should be unchanged."""
+        result = _normalize_msvc_symbols("lis r10, lbl_82017228@ha")
+        self.assertEqual(result, "lis r10, lbl_82017228@ha")
 
-    def test_non_msvc_symbol_with_question_in_middle(self) -> None:
-        """Symbol with ? in middle (not MSVC-style) should include ?."""
-        elems = list("foo?bar@ha")
-        result = parse_word(elems)
-        self.assertEqual(result, "foo?bar")
-        self.assertEqual(elems, list("@ha"))
+    def test_already_quoted_symbol_unchanged(self) -> None:
+        """Already quoted MSVC symbol should be unchanged."""
+        result = _normalize_msvc_symbols('bl "?ReadEndian@BinStream@@QAAXPAXH@Z"')
+        self.assertEqual(result, 'bl "?ReadEndian@BinStream@@QAAXPAXH@Z"')
 
-    def test_question_mark_in_valid_word(self) -> None:
-        """Verify ? is now in valid_word character set."""
-        self.assertIn("?", valid_word)
+    def test_msvc_symbol_without_reloc_unchanged(self) -> None:
+        """MSVC symbol without relocation suffix should be unchanged."""
+        result = _normalize_msvc_symbols("?foo@@bar")
+        self.assertEqual(result, "?foo@@bar")
+
+    def test_msvc_symbol_with_paren_boundary(self) -> None:
+        """MSVC symbol followed by parenthesis."""
+        result = _normalize_msvc_symbols("?foo@@bar@l(r11)")
+        self.assertEqual(result, '"?foo@@bar"@l(r11)')
+
+    def test_msvc_symbol_with_comma_boundary(self) -> None:
+        """MSVC symbol followed by comma."""
+        result = _normalize_msvc_symbols("?foo@@bar@ha, r11")
+        self.assertEqual(result, '"?foo@@bar"@ha, r11')
 
 
 class TestParseArgElemsMsvcSymbols(unittest.TestCase):
-    """Test full argument parsing with MSVC symbols."""
+    """Test full argument parsing with preprocessed (quoted) MSVC symbols.
+
+    These tests verify that once MSVC symbols are quoted by preprocessing,
+    the parser correctly handles them.
+    """
 
     def setUp(self) -> None:
         self.arch = NaiveParsingArch()
@@ -143,25 +126,26 @@ class TestParseArgElemsMsvcSymbols(unittest.TestCase):
             top_level=True,
         )
 
-    def test_msvc_symbol_with_ha_macro(self) -> None:
-        """MSVC symbol with @ha should produce Macro."""
-        result = self.parse("?TheDebug@@3VDebug@@A@ha")
+    def test_quoted_msvc_symbol_with_ha_macro(self) -> None:
+        """Quoted MSVC symbol with @ha should produce Macro."""
+        # After preprocessing: "?TheDebug@@3VDebug@@A"@ha
+        result = self.parse('"?TheDebug@@3VDebug@@A"@ha')
         self.assertIsInstance(result, Macro)
         self.assertEqual(result.macro_name, "ha")
         self.assertIsInstance(result.argument, AsmGlobalSymbol)
         self.assertEqual(result.argument.symbol_name, "?TheDebug@@3VDebug@@A")
 
-    def test_msvc_symbol_with_l_macro(self) -> None:
-        """MSVC symbol with @l should produce Macro."""
-        result = self.parse("?TheDebug@@3VDebug@@A@l")
+    def test_quoted_msvc_symbol_with_l_macro(self) -> None:
+        """Quoted MSVC symbol with @l should produce Macro."""
+        result = self.parse('"?TheDebug@@3VDebug@@A"@l')
         self.assertIsInstance(result, Macro)
         self.assertEqual(result.macro_name, "l")
         self.assertIsInstance(result.argument, AsmGlobalSymbol)
         self.assertEqual(result.argument.symbol_name, "?TheDebug@@3VDebug@@A")
 
-    def test_msvc_symbol_with_sda21_macro(self) -> None:
-        """MSVC symbol with @sda21 should produce Macro."""
-        result = self.parse("?foo@@bar@sda21")
+    def test_quoted_msvc_symbol_with_sda21_macro(self) -> None:
+        """Quoted MSVC symbol with @sda21 should produce Macro."""
+        result = self.parse('"?foo@@bar"@sda21')
         self.assertIsInstance(result, Macro)
         self.assertEqual(result.macro_name, "sda21")
         self.assertIsInstance(result.argument, AsmGlobalSymbol)
@@ -175,9 +159,9 @@ class TestParseArgElemsMsvcSymbols(unittest.TestCase):
         self.assertIsInstance(result.argument, AsmGlobalSymbol)
         self.assertEqual(result.argument.symbol_name, "lbl_82017228")
 
-    def test_msvc_symbol_no_reloc(self) -> None:
-        """MSVC symbol without relocation."""
-        result = self.parse("?foo@@bar")
+    def test_quoted_msvc_symbol_no_reloc(self) -> None:
+        """Quoted MSVC symbol without relocation."""
+        result = self.parse('"?foo@@bar"')
         self.assertIsInstance(result, AsmGlobalSymbol)
         self.assertEqual(result.symbol_name, "?foo@@bar")
 

--- a/tests/unit/test_msvc_symbols.py
+++ b/tests/unit/test_msvc_symbols.py
@@ -1,0 +1,186 @@
+"""Tests for MSVC-mangled symbol parsing in PPC assembly."""
+
+import unittest
+
+from m2c.asm_instruction import (
+    AsmGlobalSymbol,
+    AsmState,
+    Macro,
+    NaiveParsingArch,
+    parse_arg_elems,
+    parse_word,
+    valid_word,
+)
+
+
+class TestParseWordMsvcSymbols(unittest.TestCase):
+    """Test parse_word() with MSVC-mangled symbols."""
+
+    def test_simple_msvc_symbol(self) -> None:
+        """MSVC symbol without relocation."""
+        elems = list("?foo@@bar")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@@bar")
+        self.assertEqual(elems, [])
+
+    def test_msvc_symbol_with_ha_reloc(self) -> None:
+        """MSVC symbol ending with @ha relocation."""
+        elems = list("?TheDebug@@3VDebug@@A@ha")
+        result = parse_word(elems)
+        self.assertEqual(result, "?TheDebug@@3VDebug@@A")
+        self.assertEqual(elems, list("@ha"))
+
+    def test_msvc_symbol_with_l_reloc(self) -> None:
+        """MSVC symbol ending with @l relocation."""
+        elems = list("?TheDebug@@3VDebug@@A@l")
+        result = parse_word(elems)
+        self.assertEqual(result, "?TheDebug@@3VDebug@@A")
+        self.assertEqual(elems, list("@l"))
+
+    def test_msvc_symbol_with_h_reloc(self) -> None:
+        """MSVC symbol ending with @h relocation."""
+        elems = list("?foo@h")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo")
+        self.assertEqual(elems, list("@h"))
+
+    def test_msvc_symbol_with_sda21_reloc(self) -> None:
+        """MSVC symbol ending with @sda21 relocation."""
+        elems = list("?foo@@bar@sda21")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@@bar")
+        self.assertEqual(elems, list("@sda21"))
+
+    def test_msvc_symbol_with_sda2_reloc(self) -> None:
+        """MSVC symbol ending with @sda2 relocation."""
+        elems = list("?foo@@bar@sda2")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@@bar")
+        self.assertEqual(elems, list("@sda2"))
+
+    def test_msvc_double_at_before_ha_reloc(self) -> None:
+        """MSVC symbol with @@ right before @ha relocation."""
+        elems = list("?foo@@ha")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@")
+        self.assertEqual(elems, list("@ha"))
+
+    def test_msvc_at_not_reloc_followed_by_letters(self) -> None:
+        """@ha followed by more letters is NOT a relocation."""
+        elems = list("?foo@habla")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@habla")
+        self.assertEqual(elems, [])
+
+    def test_msvc_sda21_not_reloc_followed_by_letters(self) -> None:
+        """@sda21 followed by more letters is NOT a relocation."""
+        elems = list("?foo@sda21extra")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@sda21extra")
+        self.assertEqual(elems, [])
+
+    def test_msvc_at_in_middle_then_reloc(self) -> None:
+        """@h in middle of symbol, @l as relocation."""
+        elems = list("?foo@h@l")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@h")
+        self.assertEqual(elems, list("@l"))
+
+    def test_msvc_complex_real_symbol(self) -> None:
+        """Real-world MSVC symbol from dc3-decomp."""
+        elems = list("?ReadEndian@BinStream@@QAAXPAXH@Z@ha")
+        result = parse_word(elems)
+        self.assertEqual(result, "?ReadEndian@BinStream@@QAAXPAXH@Z")
+        self.assertEqual(elems, list("@ha"))
+
+    def test_msvc_symbol_with_trailing_comma(self) -> None:
+        """MSVC symbol followed by comma (operand separator)."""
+        elems = list("?foo@@bar@ha,")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@@bar")
+        self.assertEqual(elems, list("@ha,"))
+
+    def test_msvc_symbol_with_trailing_paren(self) -> None:
+        """MSVC symbol in parentheses."""
+        elems = list("?foo@@bar@l)")
+        result = parse_word(elems)
+        self.assertEqual(result, "?foo@@bar")
+        self.assertEqual(elems, list("@l)"))
+
+    def test_non_msvc_symbol_unchanged(self) -> None:
+        """Regular symbol without ? should work as before."""
+        elems = list("normalSymbol@ha")
+        result = parse_word(elems)
+        self.assertEqual(result, "normalSymbol")
+        self.assertEqual(elems, list("@ha"))
+
+    def test_non_msvc_symbol_with_question_in_middle(self) -> None:
+        """Symbol with ? in middle (not MSVC-style) should include ?."""
+        elems = list("foo?bar@ha")
+        result = parse_word(elems)
+        self.assertEqual(result, "foo?bar")
+        self.assertEqual(elems, list("@ha"))
+
+    def test_question_mark_in_valid_word(self) -> None:
+        """Verify ? is now in valid_word character set."""
+        self.assertIn("?", valid_word)
+
+
+class TestParseArgElemsMsvcSymbols(unittest.TestCase):
+    """Test full argument parsing with MSVC symbols."""
+
+    def setUp(self) -> None:
+        self.arch = NaiveParsingArch()
+        self.asm_state = AsmState()
+
+    def parse(self, arg: str) -> object:
+        """Helper to parse an argument string."""
+        elems = list(arg)
+        return parse_arg_elems(
+            elems,
+            self.arch,
+            self.asm_state,
+            top_level=True,
+        )
+
+    def test_msvc_symbol_with_ha_macro(self) -> None:
+        """MSVC symbol with @ha should produce Macro."""
+        result = self.parse("?TheDebug@@3VDebug@@A@ha")
+        self.assertIsInstance(result, Macro)
+        self.assertEqual(result.macro_name, "ha")
+        self.assertIsInstance(result.argument, AsmGlobalSymbol)
+        self.assertEqual(result.argument.symbol_name, "?TheDebug@@3VDebug@@A")
+
+    def test_msvc_symbol_with_l_macro(self) -> None:
+        """MSVC symbol with @l should produce Macro."""
+        result = self.parse("?TheDebug@@3VDebug@@A@l")
+        self.assertIsInstance(result, Macro)
+        self.assertEqual(result.macro_name, "l")
+        self.assertIsInstance(result.argument, AsmGlobalSymbol)
+        self.assertEqual(result.argument.symbol_name, "?TheDebug@@3VDebug@@A")
+
+    def test_msvc_symbol_with_sda21_macro(self) -> None:
+        """MSVC symbol with @sda21 should produce Macro."""
+        result = self.parse("?foo@@bar@sda21")
+        self.assertIsInstance(result, Macro)
+        self.assertEqual(result.macro_name, "sda21")
+        self.assertIsInstance(result.argument, AsmGlobalSymbol)
+        self.assertEqual(result.argument.symbol_name, "?foo@@bar")
+
+    def test_normal_symbol_still_works(self) -> None:
+        """Regular symbol with relocation should still work."""
+        result = self.parse("lbl_82017228@ha")
+        self.assertIsInstance(result, Macro)
+        self.assertEqual(result.macro_name, "ha")
+        self.assertIsInstance(result.argument, AsmGlobalSymbol)
+        self.assertEqual(result.argument.symbol_name, "lbl_82017228")
+
+    def test_msvc_symbol_no_reloc(self) -> None:
+        """MSVC symbol without relocation."""
+        result = self.parse("?foo@@bar")
+        self.assertIsInstance(result, AsmGlobalSymbol)
+        self.assertEqual(result.symbol_name, "?foo@@bar")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Xbox 360 code compiled with Microsoft's compiler uses MSVC-mangled C++ symbols that contain '@' characters as scope separators (e.g., `?TheDebug@@3VDebug@@A`). These symbols conflict with PPC relocation suffixes (`@ha`, `@h`, `@l`, `@sda2`, `@sda21`), causing parse failures.

## Approach

This change uses **preprocessing** to auto-quote MSVC symbols before they reach the generic parser, rather than modifying the core parsing logic. This keeps the parser clean and isolates the MSVC-specific handling:

- A new `_normalize_msvc_symbols()` function in `instruction.py` detects unquoted MSVC symbols (starting with `?`) followed by PPC relocation suffixes
- It automatically quotes the symbol portion: `?TheDebug@@3VDebug@@A@ha` → `"?TheDebug@@3VDebug@@A"@ha`
- The existing quoted-symbol parsing infrastructure handles the rest
- Only applied to PPC architecture, no impact on MIPS/ARM

## Example

```asm
# Input (fails without this fix):
lis r11, ?TheDebug@@3VDebug@@A@ha
addi r29, r11, ?TheDebug@@3VDebug@@A@l

# After preprocessing (parsed correctly):
lis r11, "?TheDebug@@3VDebug@@A"@ha
addi r29, r11, "?TheDebug@@3VDebug@@A"@l
```

## Future Improvements

The current approach works well but could be enhanced with a more formalized architecture:
- **Relocation suffixes as first-class data**: Define `relocation_suffixes: List[str]` per-architecture, making the parser truly generic
- **Symbol convention registry**: Create explicit `SymbolConvention` classes for different toolchains (MSVC, GCC, Itanium, etc.)

These would further separate concerns and make the codebase more extensible for other symbol formats. Wanted to bring it up, but also could be scope creep. I ain't an expert, just a drive by decomp'er.

## Testing

- Unit tests for the preprocessing function (`test_msvc_symbols.py`)
- Verified with real-world MSVC symbols from dc3-decomp
- All existing tests continue to pass

---

**Disclaimer:** These changes were made with Claude Code. I'm an experienced pro dev, and this change feels pretty small + easy to grok, but I feel it's important to note. Feel free to discard this and I will be happy to just use this locally for my decomp work :)