### PR TITLE
Improve  XOR 1 comparison pattern (a >= b) / (a <= b)

### DIFF
--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -93,6 +93,7 @@ from .evaluate import (
     handle_shift_right,
     handle_sltiu,
     handle_sltu,
+    handle_xori,
     handle_swl,
     handle_swr,
     imm_add_32,
@@ -1607,7 +1608,7 @@ class MipsArch(Arch):
         ),
         "xor": lambda a: BinaryOp.int(a.reg(1), "^", a.reg(2)),
         "andi": lambda a: BinaryOp.int(a.reg(1), "&", a.u16_imm(2)),
-        "xori": lambda a: BinaryOp.int(a.reg(1), "^", a.u16_imm(2)),
+        "xori": lambda a: handle_xori(a),
         # Shifts
         "sll": lambda a: fold_mul_chains(
             BinaryOp.int(a.reg(1), "<<", as_intish(a.s16_imm(2)))

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -302,6 +302,16 @@ def handle_sltiu(args: InstrArgs) -> Expression:
     return BinaryOp.ucmp(left, "<", right)
 
 
+def handle_xori(args: InstrArgs) -> Expression:
+    left = args.reg(1)
+    right = args.u16_imm(2)
+    if isinstance(right, Literal) and right.value == 1:
+        uw_left = early_unwrap(left)
+        if isinstance(uw_left, BinaryOp) and uw_left.is_comparison():
+            return uw_left.negated()
+    return BinaryOp.int(left=left, op="^", right=right)
+
+
 def handle_addi(args: InstrArgs, arm: bool = False) -> Expression:
     output_reg = args.reg_ref(0)
     source_reg = args.reg_ref(1)

--- a/tests/end_to_end/comparison/irix-o2-out.c
+++ b/tests/end_to_end/comparison/irix-o2-out.c
@@ -4,7 +4,7 @@ void test(s32 arg0, s32 arg1, s32 arg2) {
     D_410100 = arg0 == arg1;
     D_410100 = arg0 != arg2;
     D_410100 = arg0 < arg1;
-    D_410100 = (arg1 < arg0) ^ 1;
+    D_410100 = arg1 >= arg0;
     D_410100 = arg0 == 0;
     D_410100 = arg1 != 0;
 }

--- a/tests/end_to_end/gcc-division/gcc-o2-out.c
+++ b/tests/end_to_end/gcc-division/gcc-o2-out.c
@@ -299,9 +299,9 @@ void func_00401AA0(u32 arg0) {
     temp_hi_6 = arg0 / 1431655765;
     foo((u32) (temp_hi_6 + ((u32) (arg0 - temp_hi_6) >> 1)) >> 0x1E);
     foo(arg0 >> 0x1F);
-    foo((arg0 < 0x80000001U) ^ 1);
-    foo((arg0 < 0xFFFFFFFEU) ^ 1);
-    foo((arg0 < 0xFFFFFFFFU) ^ 1);
+    foo(arg0 >= 0x80000001U);
+    foo(arg0 >= 0xFFFFFFFEU);
+    foo(arg0 >= 0xFFFFFFFFU);
 }
 
 void func_00401FC4(u32 arg0) {
@@ -365,7 +365,7 @@ void func_00401FC4(u32 arg0) {
     temp_hi_6 = arg0 / 1431655765;
     foo((u32) (temp_hi_6 + ((u32) (arg0 - temp_hi_6) >> 1)) >> 0x1E);
     foo(arg0 >> 0x1F);
-    foo((arg0 < 0x80000001U) ^ 1);
-    foo((arg0 < 0xFFFFFFFEU) ^ 1);
-    foo((arg0 < 0xFFFFFFFFU) ^ 1);
+    foo(arg0 >= 0x80000001U);
+    foo(arg0 >= 0xFFFFFFFEU);
+    foo(arg0 >= 0xFFFFFFFFU);
 }


### PR DESCRIPTION
Consider the following code:
```c
int cmp_ge(int a, int b) { return a >= b; }
int cmp_le(int a, int b) { return a <= b; }
int cmp_ge_zero(int a) { return a >= 0; }
```
and the m2c decompiled code:
```c
s32 cmp_ge(s32 a, s32 b) {
    return (a < b) ^ 1;
}
s32 cmp_le(s32 a, s32 b) {
    return (b < a) ^ 1;
}
s32 cmp_ge_zero(s32 a) {
    return (a < 0) ^ 1;
}
```
and the disassembly:
```mips
slti $v0, $a0, 0x0
jr   $ra
xori $v0, $v0, 0x1
```

Pretty much every compiler and optimization emits this slt + xori 1 pattern. This PR adjusts the decompiler to output to emit just the comparison.

The decompiler output after this PR is the following:
```c
s32 cmp_ge(s32 arg0, s32 arg1) {
    return arg0 >= arg1;
}

s32 cmp_le(s32 arg0, s32 arg1) {
    return arg1 >= arg0;
}

s32 cmp_ge_zero(s32 arg0) {
    return arg0 >= 0;
}
```

I don't think this should have any false positives from this, but I did see that the existing tests expected the old pattern, so maybe somebody tried this before and reverted it?