### PR TITLE
sh2: implement preamble and return value

### DIFF
--- a/m2c/arch_mips.py
+++ b/m2c/arch_mips.py
@@ -747,6 +747,7 @@ class MipsArch(Arch):
 
     re_comment = r"[#;].*"
     supports_dollar_regs = True
+    has_delay_slots = True
 
     home_space_size = 0x10
 

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -94,6 +94,7 @@ class Sh2Arch(Arch):
         clobbers: List[Location] = []
         outputs: List[Location] = []
         is_return = False
+        is_load = False
         is_store = False
         has_delay_slot = False
         eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
@@ -142,6 +143,7 @@ class Sh2Arch(Arch):
             outputs=outputs,
             eval_fn=eval_fn,
             is_return=is_return,
+            is_load=is_load,
             is_store=is_store,
             has_delay_slot=has_delay_slot,
         )

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -5,9 +5,12 @@ from .error import DecompFailure
 from .options import Target
 from .asm_instruction import (
     Argument,
+    AsmAddressMode,
     AsmInstruction,
+    AsmLiteral,
     AsmState,
     Register,
+    Writeback,
 )
 from .instruction import (
     Instruction,
@@ -21,6 +24,7 @@ from .translate import (
     ArgLoc,
     Cast,
     Expression,
+    Literal,
     NodeState,
 )
 
@@ -32,6 +36,7 @@ class Sh2Arch(Arch):
 
     re_comment = r"!.*"
     supports_dollar_regs = False
+    supports_at_addressing = True
 
     home_space_size = 0
 
@@ -49,6 +54,7 @@ class Sh2Arch(Arch):
     saved_regs = [
         Register(r) for r in ["r8", "r9", "r10", "r11", "r12", "r13", "r14", "pr"]
     ]
+
 
     all_regs = (
         saved_regs
@@ -87,6 +93,7 @@ class Sh2Arch(Arch):
         clobbers: List[Location] = []
         outputs: List[Location] = []
         is_return = False
+        is_store = False
         has_delay_slot = False
         eval_fn: Optional[Callable[[NodeState, object], object]] = None
 
@@ -97,6 +104,30 @@ class Sh2Arch(Arch):
             has_delay_slot = True
         elif mnemonic == "nop":
             assert len(args) == 0
+        elif mnemonic == "mov":
+            assert len(args) == 2 and isinstance(args[1], Register)
+            outputs = [args[1]]
+            if isinstance(args[0], Register):
+                inputs = [args[0]]
+                eval_fn = lambda s, a: s.set_reg(a.reg_ref(1), a.reg(0))
+            else:
+                assert isinstance(args[0], AsmLiteral)
+                eval_fn = lambda s, a: s.set_reg(a.reg_ref(1), Literal(a.imm_value(0)))
+        elif mnemonic == "mov.l":
+            assert len(args) == 2
+            if isinstance(args[0], Register):
+                assert isinstance(args[1], AsmAddressMode)
+                assert args[1].base == cls.stack_pointer_reg
+                assert args[1].writeback == Writeback.PRE
+                inputs = [args[0], args[1].base]
+                is_store = True
+            else:
+                assert isinstance(args[0], AsmAddressMode)
+                assert isinstance(args[1], Register)
+                assert args[0].base == cls.stack_pointer_reg
+                assert args[0].writeback == Writeback.POST
+                inputs = [args[0].base]
+                outputs = [args[1]]
         else:
             raise DecompFailure(f"Unable to parse instruction: {mnemonic}")
 
@@ -109,6 +140,7 @@ class Sh2Arch(Arch):
             outputs=outputs,
             eval_fn=eval_fn,
             is_return=is_return,
+            is_store=is_store,
             has_delay_slot=has_delay_slot,
         )
 

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -37,6 +37,7 @@ class Sh2Arch(Arch):
     re_comment = r"!.*"
     supports_dollar_regs = False
     supports_at_addressing = True
+    has_delay_slots = True
 
     home_space_size = 0
 
@@ -127,6 +128,7 @@ class Sh2Arch(Arch):
                 assert args[0].writeback == Writeback.POST
                 inputs = [args[0].base]
                 outputs = [args[1]]
+                is_load = True
         else:
             raise DecompFailure(f"Unable to parse instruction: {mnemonic}")
 

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -24,6 +24,7 @@ from .translate import (
     ArgLoc,
     Cast,
     Expression,
+    InstrArgs,
     Literal,
     NodeState,
 )
@@ -95,7 +96,7 @@ class Sh2Arch(Arch):
         is_return = False
         is_store = False
         has_delay_slot = False
-        eval_fn: Optional[Callable[[NodeState, object], object]] = None
+        eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
 
         if mnemonic == "rts":
             assert len(args) == 0

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -55,7 +55,6 @@ class Sh2Arch(Arch):
         Register(r) for r in ["r8", "r9", "r10", "r11", "r12", "r13", "r14", "pr"]
     ]
 
-
     all_regs = (
         saved_regs
         + temp_regs

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -596,11 +596,11 @@ def parse_arg_elems(
                     expect("+")
                     sh_writeback = Writeback.POST
                 value = AsmAddressMode(base, AsmLiteral(0), sh_writeback)
-            elif not top_level:
-                # Parse a+b@l as (a+b)@l, not a+(b@l)
-                break
             else:
                 # A relocation (e.g. (...)@ha or (...)@l).
+                if not top_level:
+                    # Parse a+b@l as (a+b)@l, not a+(b@l)
+                    break
                 arg_elems.pop(0)
                 reloc_name = parse_word(arg_elems)
                 assert reloc_name in ("h", "ha", "l", "sda2", "sda21")

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -178,6 +178,8 @@ class ArchAsmParsing(abc.ABC):
     all_regs: List[Register]
     aliased_regs: Dict[str, Register]
     supports_dollar_regs: bool
+    supports_at_addressing = False
+    has_delay_slots = False
 
     @abc.abstractmethod
     def normalize_instruction(
@@ -579,7 +581,7 @@ def parse_arg_elems(
                 else:
                     value = BinOp(op, value, rhs)
         elif tok == "@":
-            if value is None and getattr(arch, "supports_at_addressing", False):
+            if value is None and arch.supports_at_addressing:
                 # SuperH indirect addressing: @Rn, @-Rn, and @Rn+.
                 expect("@")
                 writeback: Optional[Writeback] = None
@@ -594,11 +596,11 @@ def parse_arg_elems(
                     expect("+")
                     writeback = Writeback.POST
                 value = AsmAddressMode(base, AsmLiteral(0), writeback)
-            # A relocation (e.g. (...)@ha or (...)@l).
             elif not top_level:
                 # Parse a+b@l as (a+b)@l, not a+(b@l)
                 break
             else:
+                # A relocation (e.g. (...)@ha or (...)@l).
                 arg_elems.pop(0)
                 reloc_name = parse_word(arg_elems)
                 assert reloc_name in ("h", "ha", "l", "sda2", "sda21")

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -584,18 +584,18 @@ def parse_arg_elems(
             if value is None and arch.supports_at_addressing:
                 # SuperH indirect addressing: @Rn, @-Rn, and @Rn+.
                 expect("@")
-                writeback: Optional[Writeback] = None
+                sh_writeback: Optional[Writeback] = None
                 if arg_elems and arg_elems[0] == "-":
                     expect("-")
-                    writeback = Writeback.PRE
+                    sh_writeback = Writeback.PRE
                 word = parse_word(arg_elems)
                 base = replace_bare_reg(AsmGlobalSymbol(word), arch, asm_state)
                 assert isinstance(base, Register)
                 if arg_elems and arg_elems[0] == "+":
-                    assert writeback is None
+                    assert sh_writeback is None
                     expect("+")
-                    writeback = Writeback.POST
-                value = AsmAddressMode(base, AsmLiteral(0), writeback)
+                    sh_writeback = Writeback.POST
+                value = AsmAddressMode(base, AsmLiteral(0), sh_writeback)
             elif not top_level:
                 # Parse a+b@l as (a+b)@l, not a+(b@l)
                 break

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -579,15 +579,31 @@ def parse_arg_elems(
                 else:
                     value = BinOp(op, value, rhs)
         elif tok == "@":
+            if value is None and getattr(arch, "supports_at_addressing", False):
+                # SuperH indirect addressing: @Rn, @-Rn, and @Rn+.
+                expect("@")
+                writeback: Optional[Writeback] = None
+                if arg_elems and arg_elems[0] == "-":
+                    expect("-")
+                    writeback = Writeback.PRE
+                word = parse_word(arg_elems)
+                base = replace_bare_reg(AsmGlobalSymbol(word), arch, asm_state)
+                assert isinstance(base, Register)
+                if arg_elems and arg_elems[0] == "+":
+                    assert writeback is None
+                    expect("+")
+                    writeback = Writeback.POST
+                value = AsmAddressMode(base, AsmLiteral(0), writeback)
             # A relocation (e.g. (...)@ha or (...)@l).
-            if not top_level:
+            elif not top_level:
                 # Parse a+b@l as (a+b)@l, not a+(b@l)
                 break
-            arg_elems.pop(0)
-            reloc_name = parse_word(arg_elems)
-            assert reloc_name in ("h", "ha", "l", "sda2", "sda21")
-            assert value
-            value = Macro(reloc_name, value)
+            else:
+                arg_elems.pop(0)
+                reloc_name = parse_word(arg_elems)
+                assert reloc_name in ("h", "ha", "l", "sda2", "sda21")
+                assert value
+                value = Macro(reloc_name, value)
         elif tok == "=":
             # ARM reference to symbol
             assert top_level

--- a/m2c/flow_graph.py
+++ b/m2c/flow_graph.py
@@ -433,7 +433,7 @@ def build_blocks(
     branch_likely_counts: CounterPy38[str] = Counter()
     cond_return_target: Optional[str] = None
 
-    def process_mips(item: Union[Instruction, Label]) -> None:
+    def process_delay_slots(item: Union[Instruction, Label]) -> None:
         if isinstance(item, Label):
             # Split blocks at labels.
             block_builder.new_block()
@@ -567,7 +567,7 @@ def build_blocks(
             block_builder.new_block()
 
         for item in process_after:
-            process_mips(item)
+            process_delay_slots(item)
 
     def process_no_delay_slots(item: Union[Instruction, Label]) -> None:
         nonlocal cond_return_target
@@ -606,8 +606,8 @@ def build_blocks(
             block_builder.new_block()
 
     for item in body_iter:
-        if arch.arch in (Target.ArchEnum.MIPS, Target.ArchEnum.SH2):
-            process_mips(item)
+        if arch.has_delay_slots:
+            process_delay_slots(item)
         else:
             process_no_delay_slots(item)
 

--- a/m2c/flow_graph.py
+++ b/m2c/flow_graph.py
@@ -413,8 +413,10 @@ def build_blocks(
     fragment: bool,
     debug_patterns: bool,
 ) -> List[Block]:
-    if arch.arch == Target.ArchEnum.MIPS:
+    if arch.arch in (Target.ArchEnum.MIPS, Target.ArchEnum.SH2):
         verify_no_trailing_delay_slot(function)
+
+    if arch.arch == Target.ArchEnum.MIPS:
         function = minimize_labels(function, asm_data)
         function = normalize_gcc_likely_branches(function, arch)
         function = normalize_ido_likely_branches(function, arch)
@@ -604,7 +606,7 @@ def build_blocks(
             block_builder.new_block()
 
     for item in body_iter:
-        if arch.arch == Target.ArchEnum.MIPS:
+        if arch.arch in (Target.ArchEnum.MIPS, Target.ArchEnum.SH2):
             process_mips(item)
         else:
             process_no_delay_slots(item)

--- a/m2c/flow_graph.py
+++ b/m2c/flow_graph.py
@@ -413,7 +413,7 @@ def build_blocks(
     fragment: bool,
     debug_patterns: bool,
 ) -> List[Block]:
-    if arch.arch in (Target.ArchEnum.MIPS, Target.ArchEnum.SH2):
+    if arch.has_delay_slots:
         verify_no_trailing_delay_slot(function)
 
     if arch.arch == Target.ArchEnum.MIPS:

--- a/m2c/options.py
+++ b/m2c/options.py
@@ -118,7 +118,7 @@ class Target:
                 compiler = Target.CompilerEnum.MWCC
             elif arch == Target.ArchEnum.ARM:
                 compiler = Target.CompilerEnum.GCC
-            elif arch == Target.ArchEnum.SH:
+            elif arch == Target.ArchEnum.SH2:
                 compiler = Target.CompilerEnum.GCC
             else:
                 compiler = Target.CompilerEnum.IDO

--- a/tests/end_to_end/sh-return-one/sh-return-one-flags.txt
+++ b/tests/end_to_end/sh-return-one/sh-return-one-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-return-one/sh-return-one-out.c
+++ b/tests/end_to_end/sh-return-one/sh-return-one-out.c
@@ -1,0 +1,3 @@
+s32 test(void) {
+    return 1;
+}

--- a/tests/end_to_end/sh-return-one/sh-return-one.s
+++ b/tests/end_to_end/sh-return-one/sh-return-one.s
@@ -1,0 +1,7 @@
+glabel test
+/* 0x0600DE2C 0x2FE6 */ mov.l r14, @-r15
+/* 0x0600DE2E 0x6EF3 */ mov r15, r14
+/* 0x0600DE30 0x6EF6 */ mov.l @r15+, r14
+/* 0x0600DE32 0x000B */ rts
+/* 0x0600DE34 0xE001 */ mov #1, r0
+/* 0x0600DE36 */ .word 0x0009


### PR DESCRIPTION
This implements mov and mov.l instructions to support gcc function boilerplate and a simple return value like:
```
/* 0x0600DE2C 0x2FE6 */ mov.l r14, @-r15
/* 0x0600DE2E 0x6EF3 */ mov r15, r14
/* 0x0600DE30 0x6EF6 */ mov.l @r15+, r14
/* 0x0600DE32 0x000B */ rts
/* 0x0600DE34 0xE001 */ mov #1, r0
```
The @ instructions are indirect and can have a pre or post-increment.

A test is added for this case.