### PR TITLE
sh2: add ops: add, sub, tst, bt.s, bra

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import replace
 from typing import Callable, Dict, List, Optional
 
 from .error import DecompFailure
@@ -26,12 +27,13 @@ from .translate import (
     BinaryOp,
     Cast,
     Expression,
+    InstrMap,
     InstrArgs,
     Literal,
     NodeState,
 )
 
-from .evaluate import condition_from_expr
+from .evaluate import condition_from_expr, handle_add, handle_sub
 
 from .types import FunctionSignature, Type
 
@@ -137,7 +139,7 @@ class Sh2Arch(Arch):
                 inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True
-        elif mnemonic in ("add", "sub"):
+        elif mnemonic in cls.instrs_arithmetic:
             assert (
                 len(args) == 2
                 and isinstance(args[0], Register)
@@ -145,9 +147,8 @@ class Sh2Arch(Arch):
             )
             inputs = [args[0], args[1]]
             outputs = [args[1]]
-            op = "+" if mnemonic == "add" else "-"
             eval_fn = lambda s, a: s.set_reg(
-                a.reg_ref(1), BinaryOp.intptr(a.reg(1), op, a.reg(0))
+                a.reg_ref(1), cls.instrs_arithmetic[mnemonic](a)
             )
         elif mnemonic == "tst":
             assert (
@@ -201,6 +202,18 @@ class Sh2Arch(Arch):
             is_store=is_store,
             has_delay_slot=has_delay_slot,
         )
+
+    instrs_arithmetic: InstrMap = {
+        # sh2 format is src, dst
+        # add handler is dest, left, right
+        "add": lambda a: handle_add(
+            replace(
+                a,
+                raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)],
+            )
+        ),
+        "sub": lambda a: handle_sub(a.reg(1), a.reg(0)),
+    }
 
     def arg_name(self, loc: ArgLoc) -> str:
         if loc.offset is not None:

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -11,6 +11,7 @@ from .asm_instruction import (
     AsmState,
     Register,
     Writeback,
+    get_jump_target,
 )
 from .instruction import (
     Instruction,
@@ -22,12 +23,15 @@ from .translate import (
     AbiArgSlot,
     Arch,
     ArgLoc,
+    BinaryOp,
     Cast,
     Expression,
     InstrArgs,
     Literal,
     NodeState,
 )
+
+from .evaluate import condition_from_expr
 
 from .types import FunctionSignature, Type
 
@@ -51,7 +55,7 @@ class Sh2Arch(Arch):
 
     argument_regs = [Register(r) for r in ["r4", "r5", "r6", "r7"]]
     simple_temp_regs = [Register(r) for r in ["r0", "r1", "r2", "r3"]]
-    temp_regs = argument_regs + simple_temp_regs
+    temp_regs = argument_regs + simple_temp_regs + [Register("condition_bit")]
 
     saved_regs = [
         Register(r) for r in ["r8", "r9", "r10", "r11", "r12", "r13", "r14", "pr"]
@@ -97,6 +101,8 @@ class Sh2Arch(Arch):
         is_load = False
         is_store = False
         has_delay_slot = False
+        is_conditional = False
+        jump_target = None
         eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
 
         if mnemonic == "rts":
@@ -131,6 +137,52 @@ class Sh2Arch(Arch):
                 inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True
+        elif mnemonic in ("add", "sub"):
+            assert (
+                len(args) == 2
+                and isinstance(args[0], Register)
+                and isinstance(args[1], Register)
+            )
+            inputs = [args[0], args[1]]
+            outputs = [args[1]]
+            op = "+" if mnemonic == "add" else "-"
+            eval_fn = lambda s, a: s.set_reg(
+                a.reg_ref(1), BinaryOp.intptr(a.reg(1), op, a.reg(0))
+            )
+        elif mnemonic == "tst":
+            assert (
+                len(args) == 2
+                and isinstance(args[0], Register)
+                and isinstance(args[1], Register)
+            )
+            inputs = [args[0], args[1]]
+            outputs = [Register("condition_bit")]
+            same_reg = args[0] == args[1]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                # tst does '&' but gcc uses it for 'if (x == 0)' as well.
+                # so check if it's the same reg. e.g. 'tst r4, r4'
+                value = (
+                    a.reg(0) if same_reg else BinaryOp.intptr(a.reg(1), "&", a.reg(0))
+                )
+                s.set_reg(
+                    Register("condition_bit"),
+                    BinaryOp.icmp(value, "==", Literal(0)),
+                )
+
+        elif mnemonic == "bt.s":
+            assert len(args) == 1
+            inputs = [Register("condition_bit")]
+            jump_target = get_jump_target(args[0])
+            is_conditional = True
+            has_delay_slot = True
+            eval_fn = lambda s, a: s.set_branch_condition(
+                condition_from_expr(a.regs[Register("condition_bit")])
+            )
+        elif mnemonic == "bra":
+            assert len(args) == 1
+            jump_target = get_jump_target(args[0])
+            has_delay_slot = True
         else:
             raise DecompFailure(f"Unable to parse instruction: {mnemonic}")
 
@@ -142,6 +194,8 @@ class Sh2Arch(Arch):
             clobbers=clobbers,
             outputs=outputs,
             eval_fn=eval_fn,
+            jump_target=jump_target,
+            is_conditional=is_conditional,
             is_return=is_return,
             is_load=is_load,
             is_store=is_store,

--- a/m2c/asm_file.py
+++ b/m2c/asm_file.py
@@ -500,7 +500,7 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
     re_whitespace_or_string = re.compile(r'\s+|"(?:\\.|[^\\"])*"')
     re_local_glabel = re.compile("L(_.*_)?[0-9A-F]{7,8}")
     re_local_label = re.compile(
-        "loc_|locret_|def_|lbl_|LAB_|switchD_|jump_|_[0-9A-Fa-f]{7,8}(?:_.*)?$"
+        "loc_|locret_|def_|lbl_|LAB_|switchD_|jump_|L[0-9]+$|_[0-9A-Fa-f]{7,8}(?:_.*)?$"
     )
     re_label = re.compile(r'(?:([a-zA-Z0-9_.$]+)|"([a-zA-Z0-9_.$<>@,-]+)"):')
 

--- a/tests/add_test.py
+++ b/tests/add_test.py
@@ -206,9 +206,7 @@ def do_compilation_step(
 def run_compile(in_file: Path, out_file: Path, compiler: Compiler) -> None:
     flags_str = " ".join(compiler.cc_command)
     logger.info(f"Compiling {in_file} to {out_file} using: {flags_str}")
-    if compiler.name == "sh-gcc":
-        do_compilation_step(str(out_file), str(in_file), compiler)
-    elif compiler.name == "agbcc":
+    if compiler.name in ("agbcc", "sh-gcc"):
         with NamedTemporaryFile(suffix=".i") as temp_i_file:
             subprocess.run(
                 ["cpp", "-P", "-o", temp_i_file.name, str(in_file)], check=True

--- a/tests/end_to_end/sh-add-sub/orig.c
+++ b/tests/end_to_end/sh-add-sub/orig.c
@@ -1,0 +1,2 @@
+int test(int a, int b) { return a + b; }
+int minus(int a, int b) { return a - b; }

--- a/tests/end_to_end/sh-add-sub/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-add-sub/sh2-gcc-o2-flags.txt
@@ -1,0 +1,2 @@
+--target sh2-gcc-c
+--function _minus

--- a/tests/end_to_end/sh-add-sub/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-add-sub/sh2-gcc-o2-out.c
@@ -1,0 +1,7 @@
+s32 _test(s32 arg0, s32 arg1) {
+    return arg0 + arg1;
+}
+
+s32 _minus(s32 arg0, s32 arg1) {
+    return arg0 - arg1;
+}

--- a/tests/end_to_end/sh-add-sub/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-add-sub/sh2-gcc-o2.s
@@ -1,0 +1,31 @@
+	.file	"input.c"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	mov.l	@r15+,r14
+	rts
+	add	r5,r0
+	.align 2
+	.global	_minus
+_minus:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	mov.l	@r15+,r14
+	rts
+	sub	r5,r0

--- a/tests/end_to_end/sh-if-zero/orig.c
+++ b/tests/end_to_end/sh-if-zero/orig.c
@@ -1,0 +1,6 @@
+int test(int x) {
+    if (x == 0) {
+        return 1;
+    }
+    return 2;
+}

--- a/tests/end_to_end/sh-if-zero/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-if-zero/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-if-zero/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-if-zero/sh2-gcc-o2-out.c
@@ -1,0 +1,6 @@
+s32 _test(s32 arg0) {
+    if (arg0 != 0) {
+        return 2;
+    }
+    return 1;
+}

--- a/tests/end_to_end/sh-if-zero/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-if-zero/sh2-gcc-o2.s
@@ -1,0 +1,28 @@
+	.file	"input.c"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	tst	r4,r4
+	bt.s	L2
+	mov	r15,r14
+	bra	L3
+	mov	#2,r0
+L2:
+	mov	#1,r0
+L3:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14


### PR DESCRIPTION
This adds some additional ops to handle

```
int test(int a, int b) { return a + b; }
int minus(int a, int b) { return a - b; }
```

and
```
int test(int x) {
    if (x == 0) {
        return 1;
    }
    return 2;
}
```

The branching test output is wrong but I'm not sure if that's a problem with my implementation or just how m2c works.

```
s32 _test(s32 arg0) {
    // conditional swapped
    if (arg0 != 0) {
        return 2;     
    }
    return 1;
}
```

I also combined the add_test.py codepath since my tooling can handle .i files now.