### PR TITLE
sh2: add minimal ABI coverage

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -33,7 +33,14 @@ from .translate import (
     NodeState,
 )
 
-from .evaluate import condition_from_expr, handle_add, handle_sub
+from .evaluate import (
+    condition_from_expr,
+    handle_add,
+    handle_addi,
+    handle_load,
+    handle_sub,
+    make_store,
+)
 
 from .types import FunctionSignature, Type
 
@@ -123,29 +130,44 @@ class Sh2Arch(Arch):
             else:
                 assert isinstance(args[0], AsmLiteral)
                 eval_fn = lambda s, a: s.set_reg(a.reg_ref(1), Literal(a.imm_value(0)))
-        elif mnemonic == "mov.l":
+        elif mnemonic in ("mov.l", "mov.w"):
             assert len(args) == 2
             if isinstance(args[0], Register):
                 assert isinstance(args[1], AsmAddressMode)
-                assert args[1].base == cls.stack_pointer_reg
-                assert args[1].writeback == Writeback.PRE
                 inputs = [args[0], args[1].base]
                 is_store = True
+                if args[1].writeback is None:
+                    def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                        store = make_store(a, Type.reg32(likely_float=False))
+                        if store is not None:
+                            s.store_memory(store, a.reg_ref(0))
             else:
-                assert isinstance(args[0], AsmAddressMode)
                 assert isinstance(args[1], Register)
-                assert args[0].base == cls.stack_pointer_reg
-                assert args[0].writeback == Writeback.POST
-                inputs = [args[0].base]
+                if isinstance(args[0], AsmAddressMode):
+                    inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True
+                if not (
+                    isinstance(args[0], AsmAddressMode)
+                    and args[0].writeback is not None
+                ):
+                    load_type = (
+                        Type.s16()
+                        if mnemonic == "mov.w"
+                        else Type.reg32(likely_float=False)
+                    )
+                    eval_fn = lambda s, a: s.set_reg(
+                        a.reg_ref(1),
+                        handle_load(
+                            replace(a, raw_args=[a.raw_arg(1), a.raw_arg(0)]),
+                            type=load_type,
+                        ),
+                    )
         elif mnemonic in cls.instrs_arithmetic:
-            assert (
-                len(args) == 2
-                and isinstance(args[0], Register)
-                and isinstance(args[1], Register)
-            )
-            inputs = [args[0], args[1]]
+            assert len(args) == 2 and isinstance(args[1], Register)
+            inputs = [args[1]]
+            if isinstance(args[0], Register):
+                inputs.insert(0, args[0])
             outputs = [args[1]]
             eval_fn = lambda s, a: s.set_reg(
                 a.reg_ref(1), cls.instrs_arithmetic[mnemonic](a)
@@ -206,11 +228,12 @@ class Sh2Arch(Arch):
     instrs_arithmetic: InstrMap = {
         # sh2 format is src, dst
         # add handler is dest, left, right
-        "add": lambda a: handle_add(
-            replace(
-                a,
-                raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)],
-            )
+        "add": lambda a: (
+            handle_add
+            if isinstance(a.raw_arg(0), Register)
+            else handle_addi
+        )(
+            replace(a, raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)])
         ),
         "sub": lambda a: handle_sub(a.reg(1), a.reg(0)),
     }
@@ -234,6 +257,19 @@ class Sh2Arch(Arch):
         possible_slots: List[AbiArgSlot] = []
 
         if fn_sig.params_known:
+            if (
+                fn_sig.return_type.is_struct()
+                and fn_sig.return_type.get_parameter_size_align_bytes()[0] > 8
+            ):
+                known_slots.append(
+                    AbiArgSlot(
+                        ArgLoc(None, -1, Register("r2")),
+                        Type.ptr(fn_sig.return_type),
+                        name="__return__",
+                        comment="return",
+                    )
+                )
+
             for i, param in enumerate(fn_sig.params):
                 param_type = param.type.decay()
                 reg = Register(f"r{i + 4}") if i < 4 else None

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -137,10 +137,12 @@ class Sh2Arch(Arch):
                 inputs = [args[0], args[1].base]
                 is_store = True
                 if args[1].writeback is None:
+
                     def eval_fn(s: NodeState, a: InstrArgs) -> None:
                         store = make_store(a, Type.reg32(likely_float=False))
                         if store is not None:
                             s.store_memory(store, a.reg_ref(0))
+
             else:
                 assert isinstance(args[1], Register)
                 if isinstance(args[0], AsmAddressMode):
@@ -229,12 +231,8 @@ class Sh2Arch(Arch):
         # sh2 format is src, dst
         # add handler is dest, left, right
         "add": lambda a: (
-            handle_add
-            if isinstance(a.raw_arg(0), Register)
-            else handle_addi
-        )(
-            replace(a, raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)])
-        ),
+            handle_add if isinstance(a.raw_arg(0), Register) else handle_addi
+        )(replace(a, raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)])),
         "sub": lambda a: handle_sub(a.reg(1), a.reg(0)),
     }
 

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -143,6 +143,11 @@ class Sh2Arch(Arch):
                         if store is not None:
                             s.store_memory(store, a.reg_ref(0))
 
+                else:
+                    # otherwise we have a writeback
+                    assert args[1].base == cls.stack_pointer_reg
+                    assert args[1].writeback == Writeback.PRE
+
             else:
                 assert isinstance(args[1], Register)
                 if isinstance(args[0], AsmAddressMode):

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -598,7 +598,7 @@ def parse_arg_elems(
                     base = replace_bare_reg(AsmGlobalSymbol(word), arch, asm_state)
                     assert isinstance(base, Register)
                     expect(")")
-                    value = AsmAddressMode(base, constant_fold(addend, asm_state), None)
+                    value = AsmAddressMode(base, addend, None)
                     continue
                 sh_writeback: Optional[Writeback] = None
                 if arg_elems and arg_elems[0] == "-":

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -595,14 +595,10 @@ def parse_arg_elems(
                     )
                     expect(",")
                     word = parse_word(arg_elems)
-                    base = replace_bare_reg(
-                        AsmGlobalSymbol(word), arch, asm_state
-                    )
+                    base = replace_bare_reg(AsmGlobalSymbol(word), arch, asm_state)
                     assert isinstance(base, Register)
                     expect(")")
-                    value = AsmAddressMode(
-                        base, constant_fold(addend, asm_state), None
-                    )
+                    value = AsmAddressMode(base, constant_fold(addend, asm_state), None)
                     continue
                 sh_writeback: Optional[Writeback] = None
                 if arg_elems and arg_elems[0] == "-":

--- a/m2c/asm_instruction.py
+++ b/m2c/asm_instruction.py
@@ -582,8 +582,28 @@ def parse_arg_elems(
                     value = BinOp(op, value, rhs)
         elif tok == "@":
             if value is None and arch.supports_at_addressing:
-                # SuperH indirect addressing: @Rn, @-Rn, and @Rn+.
+                # SuperH indirect addressing: @Rn, @-Rn, @Rn+, and @(disp,Rn).
                 expect("@")
+                if arg_elems and arg_elems[0] == "(":
+                    expect("(")
+                    addend = parse_arg_elems(
+                        arg_elems,
+                        arch,
+                        asm_state,
+                        top_level=False,
+                        do_replace_bare_reg=False,
+                    )
+                    expect(",")
+                    word = parse_word(arg_elems)
+                    base = replace_bare_reg(
+                        AsmGlobalSymbol(word), arch, asm_state
+                    )
+                    assert isinstance(base, Register)
+                    expect(")")
+                    value = AsmAddressMode(
+                        base, constant_fold(addend, asm_state), None
+                    )
+                    continue
                 sh_writeback: Optional[Writeback] = None
                 if arg_elems and arg_elems[0] == "-":
                     expect("-")

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -468,13 +468,17 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
         if not isinstance(expr, StructAccess):
             return None
 
-        is_arm = args.stack_info.global_info.arch.arch == Target.ArchEnum.ARM
+        arch = args.stack_info.global_info.arch.arch
+        is_arm = arch == Target.ArchEnum.ARM
+        is_sh = arch == Target.ArchEnum.SH2
         if is_arm and isinstance(args.raw_arg(1), AsmAddressMode):
             # For ARM, only allow constants loaded through `ldr pool`.
             # Do allow non-zero offsets: they occur in raw agbcc output which
             # we use for tests.
             return None
-        if not is_arm and (not type.is_likely_float() or expr.offset != 0):
+        if not is_arm and not is_sh and (
+            not type.is_likely_float() or expr.offset != 0
+        ):
             # For non-ARM, only allow float constants and offset 0.
             return None
 
@@ -493,11 +497,13 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
         if data is None:
             return None
 
-        if isinstance(data, bytes) and size in (4, 8):
+        if isinstance(data, bytes) and size in (2, 4, 8):
             ent.used_as_literal = True
             endian = ">" if args.stack_info.global_info.target.is_big_endian() else "<"
-            fmt = "I" if size == 4 else "Q"
+            fmt = {2: "H", 4: "I", 8: "Q"}[size]
             val: int = struct.unpack(endian + fmt, data)[0]
+            if type.is_signed() and val & (1 << (size * 8 - 1)):
+                val -= 1 << (size * 8)
             return Literal(value=val, type=type)
 
         if is_arm and ent.is_text and isinstance(data, AsmSymbolicData):

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -481,7 +481,7 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
             and not is_sh
             and (not type.is_likely_float() or expr.offset != 0)
         ):
-            # For non-ARM, only allow float constants and offset 0.
+            # Outside of ARM/SH, only allow float constants and offset 0.
             return None
 
         target = early_unwrap(expr.struct_var)

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -476,8 +476,10 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
             # Do allow non-zero offsets: they occur in raw agbcc output which
             # we use for tests.
             return None
-        if not is_arm and not is_sh and (
-            not type.is_likely_float() or expr.offset != 0
+        if (
+            not is_arm
+            and not is_sh
+            and (not type.is_likely_float() or expr.offset != 0)
         ):
             # For non-ARM, only allow float constants and offset 0.
             return None

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -639,6 +639,22 @@ def get_stack_info(
                 if reg == Register("lr"):
                     info.is_leaf = False
         elif (
+            arch_mnemonic == "arm:sub"
+            and inst.args[0] == arch.stack_pointer_reg
+            and inst.args[1] == arch.stack_pointer_reg
+            and isinstance(inst.args[2], AsmLiteral)
+        ):
+            info.allocated_stack_size += inst.args[2].value
+        elif (
+            arch_mnemonic in ("mips:move", "arm:mov", "ppc:mr")
+            and isinstance(inst.args[0], Register)
+            and inst.args[0] in arch.frame_pointer_regs
+            and inst.args[1] == arch.stack_pointer_reg
+        ):
+            # "move fp, sp" very likely means the code is compiled with frame
+            # pointers enabled; thus fp should be treated the same as sp.
+            info.frame_pointer_reg = inst.args[0]
+        elif (
             arch_mnemonic == "sh2:add"
             and isinstance(inst.args[0], AsmLiteral)
             and inst.args[0].value < 0
@@ -658,22 +674,6 @@ def get_stack_info(
             callee_saved_offsets.append(-info.allocated_stack_size)
             if inst.args[0] == arch.return_address_reg:
                 info.is_leaf = False
-        elif (
-            arch_mnemonic == "arm:sub"
-            and inst.args[0] == arch.stack_pointer_reg
-            and inst.args[1] == arch.stack_pointer_reg
-            and isinstance(inst.args[2], AsmLiteral)
-        ):
-            info.allocated_stack_size += inst.args[2].value
-        elif (
-            arch_mnemonic in ("mips:move", "arm:mov", "ppc:mr")
-            and isinstance(inst.args[0], Register)
-            and inst.args[0] in arch.frame_pointer_regs
-            and inst.args[1] == arch.stack_pointer_reg
-        ):
-            # "move fp, sp" very likely means the code is compiled with frame
-            # pointers enabled; thus fp should be treated the same as sp.
-            info.frame_pointer_reg = inst.args[0]
         elif (
             arch_mnemonic
             in [

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -54,6 +54,7 @@ from .asm_instruction import (
     Macro,
     Register,
     RegisterList,
+    Writeback,
 )
 from .instruction import (
     Instruction,
@@ -638,6 +639,26 @@ def get_stack_info(
                 if reg == Register("lr"):
                     info.is_leaf = False
         elif (
+            arch_mnemonic == "sh2:add"
+            and isinstance(inst.args[0], AsmLiteral)
+            and inst.args[0].value < 0
+            and inst.args[1] == arch.stack_pointer_reg
+        ):
+            info.allocated_stack_size += -inst.args[0].value
+        elif (
+            arch_mnemonic == "sh2:mov.l"
+            and isinstance(inst.args[0], Register)
+            and inst.args[0] in arch.saved_regs
+            and isinstance(inst.args[1], AsmAddressMode)
+            and inst.args[1].base == arch.stack_pointer_reg
+            and inst.args[1].writeback == Writeback.PRE
+        ):
+            info.allocated_stack_size += 4
+            info.callee_save_regs.add(inst.args[0])
+            callee_saved_offsets.append(-info.allocated_stack_size)
+            if inst.args[0] == arch.return_address_reg:
+                info.is_leaf = False
+        elif (
             arch_mnemonic == "arm:sub"
             and inst.args[0] == arch.stack_pointer_reg
             and inst.args[1] == arch.stack_pointer_reg
@@ -699,6 +720,13 @@ def get_stack_info(
                         allowed_callee_save_gaps.add(stack_offset + 4)
         elif arch_mnemonic == "ppc:mflr" and inst.args[0] == Register("r0"):
             info.is_leaf = False
+        elif (
+            arch_mnemonic == "sh2:mov"
+            and inst.args[0] == arch.stack_pointer_reg
+            and isinstance(inst.args[1], Register)
+            and inst.args[1] in arch.frame_pointer_regs
+        ):
+            info.frame_pointer_reg = inst.args[1]
         elif arch_mnemonic == "mips:li" and inst.args[0] in arch.temp_regs:
             assert isinstance(inst.args[0], Register)
             assert isinstance(inst.args[1], AsmLiteral)
@@ -712,9 +740,9 @@ def get_stack_info(
             assert isinstance(inst.args[2], AsmLiteral)
             temp_reg_values[inst.args[0]] |= inst.args[2].value
 
-    if arch.arch == Target.ArchEnum.ARM:
-        # On ARM we don't know the stack size up front, so callee_saved_offsets needs
-        # to be adjusted after scanning the full first block.
+    if arch.arch in (Target.ArchEnum.ARM, Target.ArchEnum.SH2):
+        # On ARM and SH we don't know the stack size up front, so
+        # callee_saved_offsets needs to be adjusted after scanning the full first block.
         for i in range(len(callee_saved_offsets)):
             callee_saved_offsets[i] += info.allocated_stack_size
 

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -655,6 +655,13 @@ def get_stack_info(
             # pointers enabled; thus fp should be treated the same as sp.
             info.frame_pointer_reg = inst.args[0]
         elif (
+            arch_mnemonic == "sh2:mov"
+            and inst.args[0] == arch.stack_pointer_reg
+            and isinstance(inst.args[1], Register)
+            and inst.args[1] in arch.frame_pointer_regs
+        ):
+            info.frame_pointer_reg = inst.args[1]
+        elif (
             arch_mnemonic == "sh2:add"
             and isinstance(inst.args[0], AsmLiteral)
             and inst.args[0].value < 0
@@ -720,13 +727,6 @@ def get_stack_info(
                         allowed_callee_save_gaps.add(stack_offset + 4)
         elif arch_mnemonic == "ppc:mflr" and inst.args[0] == Register("r0"):
             info.is_leaf = False
-        elif (
-            arch_mnemonic == "sh2:mov"
-            and inst.args[0] == arch.stack_pointer_reg
-            and isinstance(inst.args[1], Register)
-            and inst.args[1] in arch.frame_pointer_regs
-        ):
-            info.frame_pointer_reg = inst.args[1]
         elif arch_mnemonic == "mips:li" and inst.args[0] in arch.temp_regs:
             assert isinstance(inst.args[0], Register)
             assert isinstance(inst.args[1], AsmLiteral)

--- a/tests/end_to_end/sh-abi-five-arguments/context.c
+++ b/tests/end_to_end/sh-abi-five-arguments/context.c
@@ -1,0 +1,1 @@
+int _test(int a, int b, int c, int d, int e);

--- a/tests/end_to_end/sh-abi-five-arguments/orig.c
+++ b/tests/end_to_end/sh-abi-five-arguments/orig.c
@@ -1,0 +1,3 @@
+int test(int a, int b, int c, int d, int e) {
+    return a + b + c + d + e;
+}

--- a/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2-out.c
@@ -1,0 +1,3 @@
+s32 _test(s32 a, s32 b, s32 c, s32 d, s32 e) {
+    return a + b + c + d + e;
+}

--- a/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2.s
@@ -1,0 +1,26 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	add	r5,r0
+	add	r6,r0
+	add	r7,r0
+	mov.l	@(4,r14),r1
+	mov.l	@r15+,r14
+	rts
+	add	r1,r0

--- a/tests/end_to_end/sh-abi-struct-return/context.c
+++ b/tests/end_to_end/sh-abi-struct-return/context.c
@@ -1,0 +1,7 @@
+typedef struct {
+    int a;
+    int b;
+    int c;
+} Large;
+
+Large _test(int value);

--- a/tests/end_to_end/sh-abi-struct-return/orig.c
+++ b/tests/end_to_end/sh-abi-struct-return/orig.c
@@ -1,0 +1,10 @@
+typedef struct {
+    int a;
+    int b;
+    int c;
+} Large;
+
+Large test(int value) {
+    Large ret = {value, value + 1, value + 2};
+    return ret;
+}

--- a/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2-out.c
@@ -1,0 +1,17 @@
+Large _test(Large *__return__, s32 value) {
+    s32 sp0;
+    s32 sp4;
+    s32 sp8;
+    s32 temp_r1;
+    s32 temp_r1_2;
+
+    sp0 = value;
+    temp_r1 = value + 1;
+    sp4 = temp_r1;
+    temp_r1_2 = value + 2;
+    sp8 = temp_r1_2;
+    __return__->a = value;
+    __return__->b = temp_r1;
+    __return__->c = temp_r1_2;
+    return (Large) __return__;
+}

--- a/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2.s
@@ -1,0 +1,36 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	add	#-12,r15
+	mov	r15,r14
+	mov	r2,r0
+	mov.l	r4,@r14
+	mov	r4,r1
+	add	#1,r1
+	mov.l	r1,@(4,r14)
+	mov	r4,r1
+	add	#2,r1
+	mov.l	r1,@(8,r14)
+	mov.l	r4,@r0
+	mov.l	@(4,r14),r1
+	mov.l	r1,@(4,r0)
+	mov.l	@(8,r14),r1
+	mov.l	r1,@(8,r0)
+	add	#12,r14
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14

--- a/tests/end_to_end/sh-return-literal-pool/orig.c
+++ b/tests/end_to_end/sh-return-literal-pool/orig.c
@@ -1,0 +1,3 @@
+typedef signed int s32;
+
+s32 test(void) { return 2345; }

--- a/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2-out.c
@@ -1,0 +1,3 @@
+s32 _test(void) {
+    return 0x929;
+}

--- a/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2.s
@@ -1,0 +1,24 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.w	L2,r0
+	rts
+	mov.l	@r15+,r14
+	.align 1
+L2:
+	.short	2345


### PR DESCRIPTION
This is a follow-up to https://github.com/matt-kempster/m2c/pull/318 to try and improve the function ABI handling.

I'm testing these cases:

5 arguments, the 5th will go on the stack.
```
int test(int a, int b, int c, int d, int e) {
    return a + b + c + d + e;
}
```

Hidden struct return, ret in r2, value in r4
```
// 12 byte struct, 
typedef struct {
    int a;
    int b;
    int c;
} Large;

Large test(int value) {
    Large ret = {value, value + 1, value + 2};
    return ret;
}
```

16 bit value in literal pool (not really abi related but sh2 only has 8-bit immediate intructions)
```
typedef signed int s32;

s32 test(void) { return 2345; }
```
