### PR TITLE
Sh2 function calls and better handling of _

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -38,6 +38,7 @@ from .translate import (
     InstrArgs,
     Literal,
     NodeState,
+    as_u32,
 )
 
 from .evaluate import (
@@ -316,7 +317,7 @@ class Sh2Arch(Arch):
             )
             target_reg = args[0].base
             inputs = [*cls.argument_regs, target_reg]
-            outputs = [reg for reg, _ in cls.base_return_regs]
+            outputs = list(cls.all_return_regs)
             clobbers = list(cls.temp_regs)
             function_target = target_reg
             has_delay_slot = True
@@ -454,5 +455,8 @@ class Sh2Arch(Arch):
         return {
             Register("r0"): Cast(
                 expr, reinterpret=True, silent=True, type=Type.intptr()
+            ),
+            Register("r1"): as_u32(
+                Cast(expr, reinterpret=True, silent=False, type=Type.u64())
             ),
         }

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -161,6 +161,7 @@ class Sh2Arch(Arch):
         has_delay_slot = False
         is_conditional = False
         jump_target = None
+        function_target: Optional[Argument] = None
         eval_fn: Optional[Callable[[NodeState, InstrArgs], object]] = None
 
         if mnemonic == "rts":
@@ -218,6 +219,27 @@ class Sh2Arch(Arch):
                             type=load_type,
                         ),
                     )
+        elif mnemonic == "sts.l":
+            assert (
+                len(args) == 2
+                and args[0] == Register("pr")
+                and isinstance(args[1], AsmAddressMode)
+                and args[1].base == cls.stack_pointer_reg
+                and args[1].writeback == Writeback.PRE
+            )
+            inputs = [args[0], args[1].base]
+            is_store = True
+        elif mnemonic == "lds.l":
+            assert (
+                len(args) == 2
+                and isinstance(args[0], AsmAddressMode)
+                and args[0].base == cls.stack_pointer_reg
+                and args[0].writeback == Writeback.POST
+                and args[1] == Register("pr")
+            )
+            inputs = [args[0].base]
+            outputs = [args[1]]
+            is_load = True
         elif mnemonic in cls.instrs_arithmetic:
             assert len(args) == 2 and isinstance(args[1], Register)
             inputs = [args[1]]
@@ -277,6 +299,21 @@ class Sh2Arch(Arch):
                 assert isinstance(address, AsmAddressMode)
                 s.set_switch_expr(a.regs[address.base])
 
+        elif mnemonic == "jsr":
+            assert (
+                len(args) == 1
+                and isinstance(args[0], AsmAddressMode)
+                and args[0].addend == AsmLiteral(0)
+            )
+            target_reg = args[0].base
+            inputs = [*cls.argument_regs, target_reg]
+            outputs = [reg for reg, _ in cls.base_return_regs]
+            clobbers = list(cls.temp_regs)
+            function_target = target_reg
+            has_delay_slot = True
+            eval_fn = lambda s, a: s.make_function_call(
+                a.regs[target_reg], outputs
+            )
         elif mnemonic == "tablejmp.fictive":
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []
@@ -322,6 +359,7 @@ class Sh2Arch(Arch):
             outputs=outputs,
             eval_fn=eval_fn,
             jump_target=jump_target,
+            function_target=function_target,
             is_conditional=is_conditional,
             is_return=is_return,
             is_load=is_load,

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -97,6 +97,15 @@ class JumpTablePattern(SimpleAsmPattern):
 class Sh2Arch(Arch):
     arch = Target.ArchEnum.SH2
 
+    def c_symbol_name(self, asm_name: str) -> str:
+        if (
+            len(asm_name) >= 2
+            and asm_name[0] == "_"
+            and (asm_name[1].isalpha() or asm_name[1] == "_")
+        ):
+            return asm_name[1:]
+        return asm_name
+
     re_comment = r"!.*"
     supports_dollar_regs = False
     supports_at_addressing = True
@@ -311,9 +320,7 @@ class Sh2Arch(Arch):
             clobbers = list(cls.temp_regs)
             function_target = target_reg
             has_delay_slot = True
-            eval_fn = lambda s, a: s.make_function_call(
-                a.regs[target_reg], outputs
-            )
+            eval_fn = lambda s, a: s.make_function_call(a.regs[target_reg], outputs)
         elif mnemonic == "tablejmp.fictive":
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -173,7 +173,7 @@ def fn_op(fn_name: str, args: List[Expression], type: Type) -> FuncCall:
         is_variadic=False,
     )
     return FuncCall(
-        function=GlobalSymbol(symbol_name=fn_name, type=Type.function(fn_sig)),
+        function=GlobalSymbol(c_symbol_name=fn_name, type=Type.function(fn_sig)),
         args=args,
         type=type,
     )
@@ -490,8 +490,7 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
         ):
             return None
 
-        sym_name = target.expr.symbol_name
-        ent = args.stack_info.global_info.asm_data_value(sym_name)
+        ent = target.expr.asm_data_entry
         if ent is None or not ent.is_readonly:
             return None
 
@@ -1106,7 +1105,7 @@ def array_access_from_add(
             # Make up a struct with a tag name based on the symbol & struct size.
             # Although `scale = 8` could indicate an array of longs/doubles, it seems more
             # common to be an array of structs.
-            struct_name = f"_struct_{uw_base.expr.symbol_name}_0x{scale:X}"
+            struct_name = f"_struct_{uw_base.expr.c_symbol_name}_0x{scale:X}"
             struct = typepool.get_struct_by_tag_name(
                 struct_name, stack_info.global_info.typemap
             )

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -508,7 +508,7 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
                 val -= 1 << (size * 8)
             return Literal(value=val, type=type)
 
-        if is_arm and ent.is_text and isinstance(data, AsmSymbolicData):
+        if (is_arm or is_sh) and ent.is_text and isinstance(data, AsmSymbolicData):
             sym = data.data
             addend = 0
             if (

--- a/m2c/if_statements.py
+++ b/m2c/if_statements.py
@@ -139,7 +139,7 @@ class SwitchStatement:
         elif self.jump.num_cases is None:
             comments.append("unable to parse jump table")
         elif self.jump.jump_table is not None and body_is_empty:
-            comments.append(f"jump table: {self.jump.jump_table.symbol_name}")
+            comments.append(f"jump table: {self.jump.jump_table.c_symbol_name}")
         head = f"switch ({format_expr(self.jump.control_expr, fmt)})"
         if body_is_empty:
             lines.append(fmt.with_comments(f"{head};", comments))
@@ -1447,7 +1447,7 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
         if line:
             function_lines.append(line)
 
-    fn_name = function_info.symbol.symbol_name
+    fn_name = function_info.symbol.c_symbol_name
     arg_strs = []
     for i, arg in enumerate(function_info.stack_info.arguments):
         if i == 0 and function_info.stack_info.replace_first_arg is not None:

--- a/m2c/if_statements.py
+++ b/m2c/if_statements.py
@@ -1447,7 +1447,7 @@ def get_function_text(function_info: FunctionInfo, options: Options) -> str:
         if line:
             function_lines.append(line)
 
-    fn_name = function_info.stack_info.function.name
+    fn_name = function_info.symbol.symbol_name
     arg_strs = []
     for i, arg in enumerate(function_info.stack_info.arguments):
         if i == 0 and function_info.stack_info.replace_first_arg is not None:

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -130,6 +130,10 @@ def run(options: Options) -> int:
     if not options.function_indexes_or_names:
         functions = list(all_functions.values())
     else:
+        functions_by_c_name = {
+            arch.c_symbol_name(name): function
+            for name, function in all_functions.items()
+        }
         functions = []
         for index_or_name in options.function_indexes_or_names:
             if isinstance(index_or_name, int):
@@ -142,10 +146,13 @@ def run(options: Options) -> int:
                     return 1
                 functions.append(list(all_functions.values())[index_or_name])
             else:
-                if index_or_name not in all_functions:
+                function = all_functions.get(index_or_name)
+                if function is None:
+                    function = functions_by_c_name.get(index_or_name)
+                if function is None:
                     print(f"Function {index_or_name} not found.", file=sys.stderr)
                     return 1
-                functions.append(all_functions[index_or_name])
+                functions.append(function)
 
     fmt = options.formatter()
     function_names = set(all_functions.keys())

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -436,12 +436,12 @@ class StackInfo:
     def saved_reg_symbol(self, reg_name: str) -> GlobalSymbol:
         sym_name = "saved_reg_" + reg_name
         type = self.unique_type_for("saved_reg", sym_name, Type.any_reg())
-        return GlobalSymbol(symbol_name=sym_name, type=type)
+        return GlobalSymbol(c_symbol_name=sym_name, type=type)
 
     def should_save(self, expr: Expression, offset: Optional[int]) -> bool:
         expr = early_unwrap(expr)
         if isinstance(expr, GlobalSymbol) and (
-            expr.symbol_name.startswith("saved_reg_") or expr.symbol_name == "sp"
+            expr.c_symbol_name.startswith("saved_reg_") or expr.c_symbol_name == "sp"
         ):
             return True
         if (
@@ -1648,7 +1648,7 @@ class ArrayAccess(Expression):
 
 @dataclass(eq=False)
 class GlobalSymbol(Expression):
-    symbol_name: str
+    c_symbol_name: str
     type: Type
     asm_data_entry: Optional[AsmDataEntry] = None
     symbol_in_context: bool = False
@@ -1683,7 +1683,7 @@ class GlobalSymbol(Expression):
         return ret
 
     def format(self, fmt: Formatter) -> str:
-        return self.symbol_name
+        return self.c_symbol_name
 
     def potential_array_dim(self, element_size: int) -> Tuple[int, int]:
         """
@@ -4249,7 +4249,7 @@ class GlobalInfo:
                     demangled_str = str(demangled_symbol)
 
             sym = self.global_symbol_map[sym_name] = GlobalSymbol(
-                symbol_name=c_sym_name,
+                c_symbol_name=c_sym_name,
                 type=Type.any(),
                 asm_data_entry=self.asm_data_value(sym_name),
                 demangled_str=demangled_str,

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -669,7 +669,7 @@ def get_stack_info(
         ):
             info.allocated_stack_size += -inst.args[0].value
         elif (
-            arch_mnemonic == "sh2:mov.l"
+            arch_mnemonic in ("sh2:mov.l", "sh2:sts.l")
             and isinstance(inst.args[0], Register)
             and inst.args[0] in arch.saved_regs
             and isinstance(inst.args[1], AsmAddressMode)

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -120,6 +120,10 @@ class Arch(ArchFlowGraph, ArchC):
     # These are defined here to avoid a circular import in flow_graph.py
     ir_patterns: List[IrPattern] = []
 
+    def c_symbol_name(self, asm_name: str) -> str:
+        """Convert an assembler symbol name to its C spelling."""
+        return asm_name
+
     def simplify_ir(self, flow_graph: FlowGraph) -> None:
         simplify_ir_patterns(self, flow_graph, self.ir_patterns)
 
@@ -4230,6 +4234,7 @@ class GlobalInfo:
         if sym_name in self.global_symbol_map:
             sym = self.global_symbol_map[sym_name]
         else:
+            c_sym_name = self.arch.c_symbol_name(sym_name)
             demangled_symbol: Optional[CxxSymbol] = None
             demangled_str: Optional[str] = None
             if (
@@ -4244,7 +4249,7 @@ class GlobalInfo:
                     demangled_str = str(demangled_symbol)
 
             sym = self.global_symbol_map[sym_name] = GlobalSymbol(
-                symbol_name=sym_name,
+                symbol_name=c_sym_name,
                 type=Type.any(),
                 asm_data_entry=self.asm_data_value(sym_name),
                 demangled_str=demangled_str,
@@ -4259,24 +4264,24 @@ class GlobalInfo:
             ):
                 sym.type.unify(self.vtable_type(sym_name, sym.asm_data_entry))
 
-            fn = self.typemap.functions.get(sym_name)
+            fn = self.typemap.functions.get(c_sym_name)
             ctype: Optional[CType]
             if fn is not None:
                 ctype = fn.type
             else:
-                ctype = self.typemap.var_types.get(sym_name)
+                ctype = self.typemap.var_types.get(c_sym_name)
 
             if ctype is not None:
                 sym.symbol_in_context = True
                 sym.initializer_in_typemap = (
-                    sym_name in self.typemap.vars_with_initializers
+                    c_sym_name in self.typemap.vars_with_initializers
                 )
                 if self.typepool.unk_inference and is_unk_type(ctype, self.typemap):
                     type = Type.gsym_unk_ctype(ctype, self.typemap, self.typepool)
                 else:
                     type = Type.ctype(ctype, self.typemap, self.typepool)
                 sym.type.unify(type)
-                if sym_name not in self.typepool.unknown_decls:
+                if c_sym_name not in self.typepool.unknown_decls:
                     sym.type_provided = True
             elif sym_name in self.local_functions:
                 sym.type.unify(Type.function())

--- a/tests/add_test.py
+++ b/tests/add_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import subprocess
 import sys
 from contextlib import ExitStack
@@ -204,17 +203,6 @@ def do_compilation_step(
     subprocess.run(args, check=True)
 
 
-def demangle_sh_asm(asm_text: str) -> str:
-    symbols = re.findall(r"(?m)^\s*\.global\s+(_[A-Za-z][A-Za-z0-9_]*)\s*$", asm_text)
-    for symbol in symbols:
-        asm_text = re.sub(
-            rf"(?<![A-Za-z0-9_]){re.escape(symbol)}(?![A-Za-z0-9_])",
-            symbol[1:],
-            asm_text,
-        )
-    return re.sub(r"[ \t]+(?=\r?$)", "", asm_text, flags=re.MULTILINE)
-
-
 def run_compile(in_file: Path, out_file: Path, compiler: Compiler) -> None:
     flags_str = " ".join(compiler.cc_command)
     logger.info(f"Compiling {in_file} to {out_file} using: {flags_str}")
@@ -225,7 +213,8 @@ def run_compile(in_file: Path, out_file: Path, compiler: Compiler) -> None:
             )
             do_compilation_step(str(out_file), temp_i_file.name, compiler)
             if compiler.name == "sh-gcc":
-                out_file.write_text(demangle_sh_asm(out_file.read_text()))
+                lines = out_file.read_text().splitlines()
+                out_file.write_text("\n".join(line.rstrip() for line in lines) + "\n")
     else:
         with NamedTemporaryFile(suffix=".o") as temp_o_file:
             do_compilation_step(temp_o_file.name, str(in_file), compiler)

--- a/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-abi-five-arguments/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov	r4,r0

--- a/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-abi-struct-return/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	add	#-12,r15
 	mov	r15,r14

--- a/tests/end_to_end/sh-add-sub/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-add-sub/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov	r4,r0
@@ -21,8 +21,8 @@ test:
 	rts
 	add	r5,r0
 	.align 2
-	.global	minus
-minus:
+	.global	_minus
+_minus:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov	r4,r0

--- a/tests/end_to_end/sh-argument/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-argument/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov.l	@r15+,r14

--- a/tests/end_to_end/sh-empty/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-empty/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov.l	@r15+,r14

--- a/tests/end_to_end/sh-function-call/context.c
+++ b/tests/end_to_end/sh-function-call/context.c
@@ -1,2 +1,0 @@
-int _callee(int first, int second);
-int test(int value);

--- a/tests/end_to_end/sh-function-call/context.c
+++ b/tests/end_to_end/sh-function-call/context.c
@@ -1,0 +1,2 @@
+int _callee(int first, int second);
+int test(int value);

--- a/tests/end_to_end/sh-function-call/orig.c
+++ b/tests/end_to_end/sh-function-call/orig.c
@@ -1,0 +1,5 @@
+int callee(int first, int second);
+
+int test(int value) {
+    return callee(value, value + 1) + 3;
+}

--- a/tests/end_to_end/sh-function-call/orig.c
+++ b/tests/end_to_end/sh-function-call/orig.c
@@ -1,5 +1,6 @@
 int callee(int first, int second);
+extern int global;
 
 int test(int value) {
-    return callee(value, value + 1) + 3;
+    return callee(value, value + 1) + global;
 }

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2-flags.txt
@@ -1,1 +1,1 @@
---context context.c --target sh2-gcc-c
+--context orig.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2-out.c
@@ -1,0 +1,3 @@
+s32 test(s32 value) {
+    return _callee(value, value + 1) + 3;
+}

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2-out.c
@@ -1,3 +1,3 @@
 s32 test(s32 value) {
-    return _callee(value, value + 1) + 3;
+    return callee(value, value + 1) + global;
 }

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2.s
@@ -1,0 +1,32 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	test
+test:
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov	r4,r5
+	mov.l	L2,r0
+	jsr	@r0
+	add	#1,r5
+	mov	r14,r15
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	rts
+	add	#3,r0
+L3:
+	.align 2
+L2:
+	.long	_callee

--- a/tests/end_to_end/sh-function-call/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-function-call/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	sts.l	pr,@-r15
 	mov	r15,r14
@@ -23,10 +23,14 @@ test:
 	add	#1,r5
 	mov	r14,r15
 	lds.l	@r15+,pr
+	mov.l	L3,r1
+	mov.l	@r1,r1
 	mov.l	@r15+,r14
 	rts
-	add	#3,r0
-L3:
+	add	r1,r0
+L4:
 	.align 2
 L2:
 	.long	_callee
+L3:
+	.long	_global

--- a/tests/end_to_end/sh-if-zero/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-if-zero/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	tst	r4,r4
 	bt.s	L2

--- a/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-return-literal-pool/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov.w	L2,r0

--- a/tests/end_to_end/sh-return-one/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-return-one/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r15,r14
 	mov.l	@r15+,r14

--- a/tests/end_to_end/sh-switch-jumptable-nonzero/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-switch-jumptable-nonzero/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	#3,r1
 	add	#-10,r4

--- a/tests/end_to_end/sh-switch-jumptable/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-switch-jumptable/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	#3,r1
 	cmp/hi	r1,r4

--- a/tests/end_to_end/sh-switch-no-jumptable/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-switch-no-jumptable/sh2-gcc-o2.s
@@ -12,8 +12,8 @@ gcc2_compiled.:
 ___gnu_compiled_c:
 	.text
 	.align 2
-	.global	test
-test:
+	.global	_test
+_test:
 	mov.l	r14,@-r15
 	mov	r4,r0
 	cmp/eq	#1,r0


### PR DESCRIPTION
This adds support for performing a function call, for example
```
int callee(int first, int second);
extern int global;

int test(int value) {
    return callee(value, value + 1) + global;
}
```

This also improves the handling of `_`. The simplest solution seemed to be adding `c_symbol_name` to Arch and letting that be overridden by SH.