### PR TITLE
sh2: support direct register memory transfers

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -338,14 +338,10 @@ class Sh2Arch(Arch):
             else:
                 assert isinstance(args[1], Register)
                 if isinstance(args[0], AsmAddressMode):
-                    if args[0].base == cls.stack_pointer_reg:
-                        # ex. mov.l @r15+, r14
-                        # we don't do the writeback because setup_initial_registers
-                        # sets sp to a GlobalSymbol that never gets reassigned.
-                        # stack accesses are constant offsets from it and there's
-                        # nowhere to += 4. The frame size comes from get_stack_info
-                        # which doesn't consult the epilogue
-                        assert args[0].writeback in (None, Writeback.POST)
+                    # We intentionally ignore args[0].writeback. It can only be non-None
+                    # for stack pointer writes (Sh2AddrModeWritebackPattern gets rid of
+                    # it for other registers), and then only during the epilogue, which
+                    # we don't emit any code for.
                     inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -140,18 +140,15 @@ class Sh2AddrModeWritebackPattern(AsmPattern):
                 f"for instruction: {instr}"
             )
 
+        assert addr.addend == AsmLiteral(0)
+
         new_args = list(instr.args)
-        new_args[addr_arg] = replace(addr, writeback=None, addend=AsmLiteral(0))
+        new_args[addr_arg] = replace(addr, writeback=None)
+        stride = Sh2Arch.mov_stride(instr.mnemonic)
         if addr.writeback == Writeback.PRE:
             return Replacement(
                 [
-                    AsmInstruction(
-                        "add",
-                        [
-                            AsmLiteral(-Sh2Arch.mov_stride(instr.mnemonic)),
-                            addr.base,
-                        ],
-                    ),
+                    AsmInstruction("add", [AsmLiteral(-stride), addr.base]),
                     AsmInstruction(instr.mnemonic, new_args),
                 ],
                 1,
@@ -160,10 +157,7 @@ class Sh2AddrModeWritebackPattern(AsmPattern):
         return Replacement(
             [
                 AsmInstruction(instr.mnemonic, new_args),
-                AsmInstruction(
-                    "add",
-                    [AsmLiteral(Sh2Arch.mov_stride(instr.mnemonic)), addr.base],
-                ),
+                AsmInstruction("add", [AsmLiteral(stride), addr.base]),
             ],
             1,
         )
@@ -246,16 +240,16 @@ class Sh2Arch(Arch):
         ]
     )
 
-    @classmethod
-    def mov_type(cls, mnemonic: str) -> Type:
+    @staticmethod
+    def mov_type(mnemonic: str) -> Type:
         return {
             "mov.b": Type.s8(),
             "mov.w": Type.s16(),
             "mov.l": Type.reg32(likely_float=False),
         }[mnemonic]
 
-    @classmethod
-    def mov_stride(cls, mnemonic: str) -> int:
+    @staticmethod
+    def mov_stride(mnemonic: str) -> int:
         return {
             "mov.b": 1,
             "mov.w": 2,
@@ -328,10 +322,8 @@ class Sh2Arch(Arch):
                         if store is not None:
                             s.store_memory(store, a.reg_ref(0))
 
-                elif (
-                    args[1].writeback == Writeback.PRE
-                    and args[1].base == cls.stack_pointer_reg
-                ):
+                elif args[1].base == cls.stack_pointer_reg:
+                    assert args[1].writeback == Writeback.PRE
 
                     def eval_fn(s: NodeState, a: InstrArgs) -> None:
                         source_raw = a.regs.get_raw(a.reg_ref(0))
@@ -339,11 +331,21 @@ class Sh2Arch(Arch):
                         if not s.stack_info.should_save(source_raw, None):
                             s.push_subroutine_arg(a.reg(0))
 
-                    assert args[1].base == cls.stack_pointer_reg
-                    assert args[1].writeback == Writeback.PRE
+                else:
+                    # writeback on other registers is rewritten into an explicit
+                    # add by Sh2AddrModeWritebackPattern, so no eval_fn is needed.
+                    pass
             else:
                 assert isinstance(args[1], Register)
                 if isinstance(args[0], AsmAddressMode):
+                    if args[0].base == cls.stack_pointer_reg:
+                        # ex. mov.l @r15+, r14
+                        # we don't do the writeback because setup_initial_registers
+                        # sets sp to a GlobalSymbol that never gets reassigned.
+                        # stack accesses are constant offsets from it and there's
+                        # nowhere to += 4. The frame size comes from get_stack_info
+                        # which doesn't consult the epilogue
+                        assert args[0].writeback in (None, Writeback.POST)
                     inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -18,7 +18,14 @@ from .asm_instruction import (
     Writeback,
     get_jump_target,
 )
-from .asm_pattern import AsmMatch, Replacement, SimpleAsmPattern, make_pattern
+from .asm_pattern import (
+    AsmMatch,
+    AsmMatcher,
+    AsmPattern,
+    Replacement,
+    SimpleAsmPattern,
+    make_pattern,
+)
 from .instruction import (
     Instruction,
     InstructionMeta,
@@ -38,7 +45,6 @@ from .translate import (
     InstrArgs,
     Literal,
     NodeState,
-    StoreStmt,
     UnaryOp,
     as_s16,
     as_type,
@@ -101,6 +107,65 @@ class JumpTablePattern(SimpleAsmPattern):
                 AsmInstruction("nop", []),
             ],
             len(m.body),
+        )
+
+
+class Sh2AddrModeWritebackPattern(AsmPattern):
+    """Replace writebacks in mov address modes by separate add instructions."""
+
+    def match(self, matcher: AsmMatcher) -> Optional[Replacement]:
+        instr = matcher.input[matcher.index]
+        if not isinstance(instr, Instruction) or not instr.args:
+            return None
+        if instr.mnemonic not in ("mov.b", "mov.w", "mov.l"):
+            return None
+
+        if isinstance(instr.args[0], AsmAddressMode):
+            addr = instr.args[0]
+            addr_arg = 0
+        elif isinstance(instr.args[1], AsmAddressMode):
+            addr = instr.args[1]
+            addr_arg = 1
+        else:
+            return None
+
+        if addr.writeback is None:
+            return None
+        if addr.base == Sh2Arch.stack_pointer_reg:
+            return None
+
+        if addr.base in (instr.args[0], instr.args[1]):
+            raise DecompFailure(
+                "Writeback with base register also used as load/store value, "
+                f"for instruction: {instr}"
+            )
+
+        new_args = list(instr.args)
+        new_args[addr_arg] = replace(addr, writeback=None, addend=AsmLiteral(0))
+        if addr.writeback == Writeback.PRE:
+            return Replacement(
+                [
+                    AsmInstruction(
+                        "add",
+                        [
+                            AsmLiteral(-Sh2Arch.mov_stride(instr.mnemonic)),
+                            addr.base,
+                        ],
+                    ),
+                    AsmInstruction(instr.mnemonic, new_args),
+                ],
+                1,
+            )
+
+        return Replacement(
+            [
+                AsmInstruction(instr.mnemonic, new_args),
+                AsmInstruction(
+                    "add",
+                    [AsmLiteral(Sh2Arch.mov_stride(instr.mnemonic)), addr.base],
+                ),
+            ],
+            1,
         )
 
 
@@ -181,6 +246,22 @@ class Sh2Arch(Arch):
         ]
     )
 
+    @classmethod
+    def mov_type(cls, mnemonic: str) -> Type:
+        return {
+            "mov.b": Type.s8(),
+            "mov.w": Type.s16(),
+            "mov.l": Type.reg32(likely_float=False),
+        }[mnemonic]
+
+    @classmethod
+    def mov_stride(cls, mnemonic: str) -> int:
+        return {
+            "mov.b": 1,
+            "mov.w": 2,
+            "mov.l": 4,
+        }[mnemonic]
+
     aliased_regs: Dict[str, Register] = {}
 
     @classmethod
@@ -233,7 +314,7 @@ class Sh2Arch(Arch):
             else:
                 assert isinstance(args[0], AsmLiteral)
                 eval_fn = lambda s, a: s.set_reg(a.reg_ref(1), Literal(a.imm_value(0)))
-        elif mnemonic in ("mov.l", "mov.w"):
+        elif mnemonic in ("mov.b", "mov.l", "mov.w"):
             assert len(args) == 2
             if isinstance(args[0], Register):
                 assert isinstance(args[1], AsmAddressMode)
@@ -242,19 +323,22 @@ class Sh2Arch(Arch):
                 if args[1].writeback is None:
 
                     def eval_fn(s: NodeState, a: InstrArgs) -> None:
-                        store = make_store(a, Type.reg32(likely_float=False))
+                        store_type = cls.mov_type(mnemonic)
+                        store = make_store(a, store_type)
                         if store is not None:
                             s.store_memory(store, a.reg_ref(0))
 
                 elif (
-                    args[1].writeback == Writeback.PRE and args[0] not in cls.saved_regs
+                    args[1].writeback == Writeback.PRE
+                    and args[1].base == cls.stack_pointer_reg
                 ):
 
                     def eval_fn(s: NodeState, a: InstrArgs) -> None:
-                        s.push_subroutine_arg(a.reg(0))
+                        source_raw = a.regs.get_raw(a.reg_ref(0))
+                        assert source_raw is not None
+                        if not s.stack_info.should_save(source_raw, None):
+                            s.push_subroutine_arg(a.reg(0))
 
-                else:
-                    # otherwise we have a writeback
                     assert args[1].base == cls.stack_pointer_reg
                     assert args[1].writeback == Writeback.PRE
             else:
@@ -263,22 +347,14 @@ class Sh2Arch(Arch):
                     inputs = [args[0].base]
                 outputs = [args[1]]
                 is_load = True
-                if not (
-                    isinstance(args[0], AsmAddressMode)
-                    and args[0].writeback is not None
-                ):
-                    load_type = (
-                        Type.s16()
-                        if mnemonic == "mov.w"
-                        else Type.reg32(likely_float=False)
-                    )
-                    eval_fn = lambda s, a: s.set_reg(
-                        a.reg_ref(1),
-                        handle_load(
-                            replace(a, raw_args=[a.raw_arg(1), a.raw_arg(0)]),
-                            type=load_type,
-                        ),
-                    )
+                load_type = cls.mov_type(mnemonic)
+                eval_fn = lambda s, a: s.set_reg(
+                    a.reg_ref(1),
+                    handle_load(
+                        replace(a, raw_args=[a.raw_arg(1), a.raw_arg(0)]),
+                        type=load_type,
+                    ),
+                )
         elif mnemonic == "sts.l":
             assert (
                 len(args) == 2
@@ -551,7 +627,11 @@ class Sh2Arch(Arch):
         ),
     }
 
-    asm_patterns = [DivisionHelperPattern(), JumpTablePattern()]
+    asm_patterns = [
+        DivisionHelperPattern(),
+        JumpTablePattern(),
+        Sh2AddrModeWritebackPattern(),
+    ]
 
     def arg_name(self, loc: ArgLoc) -> str:
         if loc.offset is not None:

--- a/tests/end_to_end/sh-direct-register-memory/context.c
+++ b/tests/end_to_end/sh-direct-register-memory/context.c
@@ -1,0 +1,12 @@
+signed char test(signed char *ptr);
+signed short test_loadw(signed short *ptr);
+signed test_loadl(signed *ptr);
+void test_storeb(signed char *ptr, signed char value);
+void test_storew(signed short *ptr, signed short value);
+void test_storel(signed *ptr, signed value);
+signed char test_loadb_postinc(signed char **ptr);
+signed short test_loadw_postinc(signed short **ptr);
+signed test_loadl_postinc(signed **ptr);
+void test_storeb_predec(signed char **ptr, signed char value);
+void test_storew_predec(signed short **ptr, signed short value);
+void test_storel_predec(signed **ptr, signed value);

--- a/tests/end_to_end/sh-direct-register-memory/orig.c
+++ b/tests/end_to_end/sh-direct-register-memory/orig.c
@@ -1,0 +1,62 @@
+signed char test(signed char *ptr) {
+    return *ptr;
+}
+
+signed short test_loadw(signed short *ptr) {
+    return *ptr;
+}
+
+signed test_loadl(signed *ptr) {
+    return *ptr;
+}
+
+void test_storeb(signed char *ptr, signed char value) {
+    *ptr = value;
+}
+
+void test_storew(signed short *ptr, signed short value) {
+    *ptr = value;
+}
+
+void test_storel(signed *ptr, signed value) {
+    *ptr = value;
+}
+
+signed char test_loadb_postinc(signed char **ptr) {
+    signed char *current = *ptr;
+    signed char value = *current++;
+    *ptr = current;
+    return value;
+}
+
+signed short test_loadw_postinc(signed short **ptr) {
+    signed short *current = *ptr;
+    signed short value = *current++;
+    *ptr = current;
+    return value;
+}
+
+signed test_loadl_postinc(signed **ptr) {
+    signed *current = *ptr;
+    signed value = *current++;
+    *ptr = current;
+    return value;
+}
+
+void test_storeb_predec(signed char **ptr, signed char value) {
+    signed char *current = *ptr;
+    *--current = value;
+    *ptr = current;
+}
+
+void test_storew_predec(signed short **ptr, signed short value) {
+    signed short *current = *ptr;
+    *--current = value;
+    *ptr = current;
+}
+
+void test_storel_predec(signed **ptr, signed value) {
+    signed *current = *ptr;
+    *--current = value;
+    *ptr = current;
+}

--- a/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c -f test_loadw -f test_loadl -f test_storeb -f test_storew -f test_storel -f test_loadb_postinc -f test_loadw_postinc -f test_loadl_postinc -f test_storeb_predec -f test_storew_predec -f test_storel_predec

--- a/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-out.c
@@ -1,0 +1,71 @@
+s8 test(s8 *ptr) {
+    return *ptr;
+}
+
+s16 test_loadw(s16 *ptr) {
+    return *ptr;
+}
+
+s32 test_loadl(s32 *ptr) {
+    return *ptr;
+}
+
+void test_storeb(s8 *ptr, s8 value) {
+    *ptr = value;
+}
+
+void test_storew(s16 *ptr, s16 value) {
+    *ptr = value;
+}
+
+void test_storel(s32 *ptr, s32 value) {
+    *ptr = value;
+}
+
+s8 test_loadb_postinc(s8 **ptr) {
+    s8 *temp_r1;
+
+    temp_r1 = *ptr;
+    *ptr = temp_r1 + 1;
+    return *temp_r1;
+}
+
+s16 test_loadw_postinc(s16 **ptr) {
+    s16 *temp_r1;
+
+    temp_r1 = *ptr;
+    *ptr = temp_r1 + 2;
+    return *temp_r1;
+}
+
+s32 test_loadl_postinc(s32 **ptr) {
+    s32 *temp_r1;
+
+    temp_r1 = *ptr;
+    *ptr = temp_r1 + 4;
+    return *temp_r1;
+}
+
+void test_storeb_predec(s8 **ptr, s8 value) {
+    s8 *temp_r1;
+
+    temp_r1 = *ptr - 1;
+    *temp_r1 = value;
+    *ptr = temp_r1;
+}
+
+void test_storew_predec(s16 **ptr, s16 value) {
+    s16 *temp_r1;
+
+    temp_r1 = *ptr - 2;
+    *temp_r1 = value;
+    *ptr = temp_r1;
+}
+
+void test_storel_predec(s32 **ptr, s32 value) {
+    s32 *temp_r1;
+
+    temp_r1 = *ptr - 4;
+    *temp_r1 = value;
+    *ptr = temp_r1;
+}

--- a/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2.s
@@ -1,0 +1,121 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.b	@r4,r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadw
+_test_loadw:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.w	@r4,r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadl
+_test_loadl:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	@r4,r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storeb
+_test_storeb:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.b	r5,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storew
+_test_storew:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.w	r5,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storel
+_test_storel:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	r5,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadb_postinc
+_test_loadb_postinc:
+	mov.l	r14,@-r15
+	mov.l	@r4,r1
+	mov	r15,r14
+	mov.b	@r1+,r0
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadw_postinc
+_test_loadw_postinc:
+	mov.l	r14,@-r15
+	mov.l	@r4,r1
+	mov	r15,r14
+	mov.w	@r1+,r0
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadl_postinc
+_test_loadl_postinc:
+	mov.l	r14,@-r15
+	mov.l	@r4,r1
+	mov	r15,r14
+	mov.l	@r1+,r0
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storeb_predec
+_test_storeb_predec:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	@r4,r1
+	mov.b	r5,@-r1
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storew_predec
+_test_storew_predec:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	@r4,r1
+	mov.w	r5,@-r1
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storel_predec
+_test_storel_predec:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	@r4,r1
+	mov.l	r5,@-r1
+	mov.l	r1,@r4
+	rts
+	mov.l	@r15+,r14

--- a/tests/end_to_end/sh-saved-reg-stack-arg/context.c
+++ b/tests/end_to_end/sh-saved-reg-stack-arg/context.c
@@ -1,0 +1,1 @@
+int callee(int a, int b, int c, int d, int e);

--- a/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2-out.c
@@ -1,0 +1,3 @@
+void test(void) {
+    callee(1, 2, 3, 4, 5);
+}

--- a/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-saved-reg-stack-arg/sh2-gcc-o2.s
@@ -1,0 +1,24 @@
+	.file	"input.s"
+	.global	_test
+	.text
+	.align 2
+_test:
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov	#1,r4
+	mov	#2,r5
+	mov	#3,r6
+	mov	#4,r7
+	mov	#5,r8
+	mov.l	r8,@-r15
+	mov.l	L1,r0
+	jsr	@r0
+	nop
+	mov.l	@r15+,r14
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L1:
+	.long	_callee

--- a/tests/end_to_end/sh-writeback-non-r15/context.c
+++ b/tests/end_to_end/sh-writeback-non-r15/context.c
@@ -1,0 +1,4 @@
+signed test(signed **ptr);
+void test_storel_predec(signed **ptr, signed value);
+signed char test_loadb_predec(signed char **ptr);
+signed short test_loadw_predec(signed short **ptr);

--- a/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c -f test_storel_predec -f test_loadb_predec -f test_loadw_predec

--- a/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-out.c
@@ -1,0 +1,31 @@
+s32 test(s32 **ptr) {
+    s32 *temp_r1;
+
+    temp_r1 = *ptr;
+    *ptr = temp_r1 + 4;
+    return *temp_r1;
+}
+
+void test_storel_predec(s32 **ptr, s32 value) {
+    s32 *temp_r1;
+
+    temp_r1 = *ptr - 4;
+    *temp_r1 = value;
+    *ptr = temp_r1;
+}
+
+s8 test_loadb_predec(s8 **ptr) {
+    s8 *temp_r1;
+
+    temp_r1 = *ptr - 1;
+    *ptr = temp_r1;
+    return *temp_r1;
+}
+
+s16 test_loadw_predec(s16 **ptr) {
+    s16 *temp_r1;
+
+    temp_r1 = *ptr - 2;
+    *ptr = temp_r1;
+    return *temp_r1;
+}

--- a/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2.s
@@ -1,0 +1,34 @@
+    .file   "input.s"
+    .text
+    .align  2
+    .global _test
+_test:
+    mov.l   @r4, r1
+    mov.l   @r1+, r0
+    mov.l   r1, @r4
+    rts
+    nop
+    .align  2
+    .global _test_storel_predec
+_test_storel_predec:
+    mov.l   @r4, r1
+    mov.l   r5, @-r1
+    mov.l   r1, @r4
+    rts
+    nop
+    .align  2
+    .global _test_loadb_predec
+_test_loadb_predec:
+    mov.l   @r4, r1
+    mov.b   @-r1, r0
+    mov.l   r1, @r4
+    rts
+    nop
+    .align  2
+    .global _test_loadw_predec
+_test_loadw_predec:
+    mov.l   @r4, r1
+    mov.w   @-r1, r0
+    mov.l   r1, @r4
+    rts
+    nop


### PR DESCRIPTION
This adds a number of `mov` instructions needed to manipulate pointers like: `*ptr`, `*--ptr`, `*ptr--` etc.