### PR TITLE
sh2: support displacement and indexed memory transfers

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -60,9 +60,11 @@ from .evaluate import (
     handle_addi,
     handle_bitinv,
     handle_load,
+    handle_loadx,
     handle_or,
     handle_sub,
     make_store,
+    make_storex,
 )
 
 from .types import FunctionSignature, Type
@@ -313,12 +315,29 @@ class Sh2Arch(Arch):
             if isinstance(args[0], Register):
                 assert isinstance(args[1], AsmAddressMode)
                 inputs = [args[0], args[1].base]
+                if isinstance(args[1].addend, Register):
+                    inputs.append(args[1].addend)
                 is_store = True
                 if args[1].writeback is None:
 
                     def eval_fn(s: NodeState, a: InstrArgs) -> None:
                         store_type = cls.mov_type(mnemonic)
-                        store = make_store(a, store_type)
+                        address = a.raw_arg(1)
+                        assert isinstance(address, AsmAddressMode)
+                        if isinstance(address.addend, Register):
+                            store = make_storex(
+                                replace(
+                                    a,
+                                    raw_args=[
+                                        a.raw_arg(0),
+                                        address.base,
+                                        address.addend,
+                                    ],
+                                ),
+                                store_type,
+                            )
+                        else:
+                            store = make_store(a, store_type)
                         if store is not None:
                             s.store_memory(store, a.reg_ref(0))
 
@@ -343,16 +362,38 @@ class Sh2Arch(Arch):
                     # it for other registers), and then only during the epilogue, which
                     # we don't emit any code for.
                     inputs = [args[0].base]
+                    if isinstance(args[0].addend, Register):
+                        inputs.append(args[0].addend)
                 outputs = [args[1]]
                 is_load = True
                 load_type = cls.mov_type(mnemonic)
-                eval_fn = lambda s, a: s.set_reg(
-                    a.reg_ref(1),
-                    handle_load(
-                        replace(a, raw_args=[a.raw_arg(1), a.raw_arg(0)]),
-                        type=load_type,
-                    ),
-                )
+                if isinstance(args[0], AsmAddressMode) and isinstance(
+                    args[0].addend, Register
+                ):
+                    indexed_base = args[0].base
+                    indexed_addend = args[0].addend
+                    eval_fn = lambda s, a: s.set_reg(
+                        a.reg_ref(1),
+                        handle_loadx(
+                            replace(
+                                a,
+                                raw_args=[
+                                    a.raw_arg(1),
+                                    indexed_base,
+                                    indexed_addend,
+                                ],
+                            ),
+                            type=load_type,
+                        ),
+                    )
+                else:
+                    eval_fn = lambda s, a: s.set_reg(
+                        a.reg_ref(1),
+                        handle_load(
+                            replace(a, raw_args=[a.raw_arg(1), a.raw_arg(0)]),
+                            type=load_type,
+                        ),
+                    )
         elif mnemonic == "sts.l":
             assert (
                 len(args) == 2

--- a/tests/end_to_end/sh-displacement-indexed-memory/context.c
+++ b/tests/end_to_end/sh-displacement-indexed-memory/context.c
@@ -1,0 +1,12 @@
+signed char test(signed char *ptr);
+signed short test_loadw_disp(signed short *ptr);
+signed test_loadl_disp(signed *ptr);
+void test_storeb_disp(signed char *ptr, signed char value);
+void test_storew_disp(signed short *ptr, signed short value);
+void test_storel_disp(signed *ptr, signed value);
+signed char test_loadb_indexed(signed char *ptr, unsigned index);
+signed short test_loadw_indexed(signed short *ptr, unsigned index);
+signed test_loadl_indexed(signed *ptr, unsigned index);
+void test_storeb_indexed(signed char *ptr, unsigned index, signed char value);
+void test_storew_indexed(signed short *ptr, unsigned index, signed short value);
+void test_storel_indexed(signed *ptr, unsigned index, signed value);

--- a/tests/end_to_end/sh-displacement-indexed-memory/orig.c
+++ b/tests/end_to_end/sh-displacement-indexed-memory/orig.c
@@ -1,0 +1,47 @@
+signed char test(signed char *ptr) {
+    return ptr[3];
+}
+
+signed short test_loadw_disp(signed short *ptr) {
+    return ptr[3];
+}
+
+signed test_loadl_disp(signed *ptr) {
+    return ptr[3];
+}
+
+void test_storeb_disp(signed char *ptr, signed char value) {
+    ptr[3] = value;
+}
+
+void test_storew_disp(signed short *ptr, signed short value) {
+    ptr[3] = value;
+}
+
+void test_storel_disp(signed *ptr, signed value) {
+    ptr[3] = value;
+}
+
+signed char test_loadb_indexed(signed char *ptr, unsigned index) {
+    return ptr[index];
+}
+
+signed short test_loadw_indexed(signed short *ptr, unsigned index) {
+    return ptr[index];
+}
+
+signed test_loadl_indexed(signed *ptr, unsigned index) {
+    return ptr[index];
+}
+
+void test_storeb_indexed(signed char *ptr, unsigned index, signed char value) {
+    ptr[index] = value;
+}
+
+void test_storew_indexed(signed short *ptr, unsigned index, signed short value) {
+    ptr[index] = value;
+}
+
+void test_storel_indexed(signed *ptr, unsigned index, signed value) {
+    ptr[index] = value;
+}

--- a/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c --function test_loadw_disp --function test_loadl_disp --function test_storeb_disp --function test_storew_disp --function test_storel_disp --function test_loadb_indexed --function test_loadw_indexed --function test_loadl_indexed --function test_storeb_indexed --function test_storew_indexed --function test_storel_indexed

--- a/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2-out.c
@@ -1,0 +1,47 @@
+s8 test(s8 *ptr) {
+    return ptr->unk3;
+}
+
+s16 test_loadw_disp(s16 *ptr) {
+    return ptr->unk6;
+}
+
+s32 test_loadl_disp(s32 *ptr) {
+    return ptr->unkC;
+}
+
+void test_storeb_disp(s8 *ptr, s8 value) {
+    ptr->unk3 = value;
+}
+
+void test_storew_disp(s16 *ptr, s16 value) {
+    ptr->unk6 = value;
+}
+
+void test_storel_disp(s32 *ptr, s32 value) {
+    ptr->unkC = value;
+}
+
+s8 test_loadb_indexed(s8 *ptr, u32 index) {
+    return ptr[index];
+}
+
+s16 test_loadw_indexed(s16 *ptr, u32 index) {
+    return ptr[index];
+}
+
+s32 test_loadl_indexed(s32 *ptr, u32 index) {
+    return ptr[index];
+}
+
+void test_storeb_indexed(s8 *ptr, u32 index, s8 value) {
+    ptr[index] = value;
+}
+
+void test_storew_indexed(s16 *ptr, u32 index, s16 value) {
+    ptr[index] = value;
+}
+
+void test_storel_indexed(s32 *ptr, u32 index, s32 value) {
+    ptr[index] = value;
+}

--- a/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-displacement-indexed-memory/sh2-gcc-o2.s
@@ -1,0 +1,123 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	add	#3,r4
+	mov.b	@r4,r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadw_disp
+_test_loadw_disp:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	add	#6,r4
+	mov.w	@r4,r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadl_disp
+_test_loadl_disp:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	@(12,r4),r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storeb_disp
+_test_storeb_disp:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	add	#3,r4
+	mov.b	r5,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storew_disp
+_test_storew_disp:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	add	#6,r4
+	mov.w	r5,@r4
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storel_disp
+_test_storel_disp:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov.l	r5,@(12,r4)
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadb_indexed
+_test_loadb_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	mov.b	@(r0,r4),r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadw_indexed
+_test_loadw_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	add	r0,r0
+	mov.w	@(r0,r4),r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loadl_indexed
+_test_loadl_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	shll2	r0
+	mov.l	@(r0,r4),r0
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storeb_indexed
+_test_storeb_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	mov.b	r6,@(r0,r4)
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storew_indexed
+_test_storew_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	add	r0,r0
+	mov.w	r6,@(r0,r4)
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_storel_indexed
+_test_storel_indexed:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r5,r0
+	shll2	r0
+	mov.l	r6,@(r0,r4)
+	rts
+	mov.l	@r15+,r14


### PR DESCRIPTION
This contains changes to support functions like

```
signed test_loadl_indexed(signed *ptr, unsigned index) {
    return ptr[index];
}

void test_storeb_indexed(signed char *ptr, unsigned index, signed char value) {
    ptr[index] = value;
}
```