### PR TITLE
sh2: support additional branch forms

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -472,6 +472,21 @@ class Sh2Arch(Arch):
                     s.set_reg(Register("condition_bit"), carry)
                 s.set_reg(a.reg_ref(0), cls.instrs_shift[mnemonic](a))
 
+        elif mnemonic == "dt":
+            assert len(args) == 1 and isinstance(args[0], Register)
+            inputs = [args[0]]
+            outputs = [args[0], Register("condition_bit")]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                value = s.set_reg(
+                    a.reg_ref(0),
+                    BinaryOp.intptr(a.reg(0), "-", Literal(1)),
+                )
+                s.set_reg(
+                    Register("condition_bit"),
+                    BinaryOp.icmp(value, "==", Literal(0)),
+                )
+
         elif mnemonic == "tst":
             assert (
                 len(args) == 2
@@ -493,15 +508,19 @@ class Sh2Arch(Arch):
                     BinaryOp.icmp(value, "==", Literal(0)),
                 )
 
-        elif mnemonic == "bt.s":
+        elif mnemonic in ("bf.s", "bt.s"):
             assert len(args) == 1
             inputs = [Register("condition_bit")]
             jump_target = get_jump_target(args[0])
             is_conditional = True
             has_delay_slot = True
-            eval_fn = lambda s, a: s.set_branch_condition(
-                condition_from_expr(a.regs[Register("condition_bit")])
-            )
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                condition = condition_from_expr(a.regs[Register("condition_bit")])
+                if mnemonic == "bf.s":
+                    condition = condition.negated()
+                s.set_branch_condition(condition)
+
         elif mnemonic == "bra":
             assert len(args) == 1
             jump_target = get_jump_target(args[0])

--- a/tests/end_to_end/sh-branch-call-forms/context.c
+++ b/tests/end_to_end/sh-branch-call-forms/context.c
@@ -1,0 +1,6 @@
+signed callee(signed value);
+signed test(signed value);
+signed test_if_nonzero(signed value);
+signed test_if_greater(signed lhs, signed rhs);
+signed test_loop(signed value);
+signed test_call(signed value);

--- a/tests/end_to_end/sh-branch-call-forms/orig.c
+++ b/tests/end_to_end/sh-branch-call-forms/orig.c
@@ -1,0 +1,35 @@
+extern signed callee(signed value);
+
+signed test(signed value) {
+    if (value == 0) {
+        return 1;
+    }
+    return 2;
+}
+
+signed test_if_nonzero(signed value) {
+    if (value != 0) {
+        return 3;
+    }
+    return 4;
+}
+
+signed test_if_greater(signed lhs, signed rhs) {
+    if (lhs > rhs) {
+        return lhs;
+    }
+    return rhs;
+}
+
+signed test_loop(signed value) {
+    signed result = 0;
+    while (value != 0) {
+        result += value;
+        value--;
+    }
+    return result;
+}
+
+signed test_call(signed value) {
+    return callee(value) + 1;
+}

--- a/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c --function test_if_nonzero --function test_if_greater --function test_loop --function test_call

--- a/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2-out.c
@@ -1,0 +1,45 @@
+s32 test(s32 value) {
+    if (value != 0) {
+        return 2;
+    }
+    return 1;
+}
+
+s32 test_if_nonzero(s32 value) {
+    if (value == 0) {
+        return 4;
+    }
+    return 3;
+}
+
+s32 test_if_greater(s32 lhs, s32 rhs) {
+    s32 var_r0;
+
+    var_r0 = rhs;
+    if (lhs > var_r0) {
+        var_r0 = lhs;
+    }
+    return var_r0;
+}
+
+s32 test_loop(s32 value) {
+    s32 var_r0;
+    s32 var_r0_2;
+    s32 var_r4;
+
+    var_r4 = value;
+    var_r0 = 0;
+    if (var_r4 != 0) {
+        var_r0_2 = var_r4;
+        do {
+            var_r4 -= 1;
+            var_r0_2 += var_r4;
+        } while (var_r4 != 0);
+        var_r0 = var_r0_2 - var_r4;
+    }
+    return var_r0;
+}
+
+s32 test_call(s32 value) {
+    return callee(value) + 1;
+}

--- a/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-branch-call-forms/sh2-gcc-o2.s
@@ -1,0 +1,92 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	tst	r4,r4
+	bt.s	L2
+	mov	r15,r14
+	bra	L3
+	mov	#2,r0
+L2:
+	mov	#1,r0
+L3:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_if_nonzero
+_test_if_nonzero:
+	mov.l	r14,@-r15
+	tst	r4,r4
+	bf.s	L5
+	mov	r15,r14
+	bra	L6
+	mov	#4,r0
+L5:
+	mov	#3,r0
+L6:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_if_greater
+_test_if_greater:
+	mov.l	r14,@-r15
+	mov	r4,r1
+	mov	r5,r0
+	cmp/gt	r0,r1
+	bf.s	L9
+	mov	r15,r14
+	mov	r1,r0
+L9:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_loop
+_test_loop:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	tst	r4,r4
+	bt.s	L12
+	mov	#0,r0
+	add	r4,r0
+L15:
+	dt	r4
+	bf.s	L15
+	add	r4,r0
+	sub	r4,r0
+L12:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14
+	.align 2
+	.global	_test_call
+_test_call:
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov.l	L17,r0
+	jsr	@r0
+	mov	r15,r14
+	mov	r14,r15
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	rts
+	add	#1,r0
+L18:
+	.align 2
+L17:
+	.long	_callee


### PR DESCRIPTION
This adds some missing instructions to support branching like
```
signed test_if_nonzero(signed value) {
    if (value != 0) {
        return 3;
    }
    return 4;
}

signed test_if_greater(signed lhs, signed rhs) {
    if (lhs > rhs) {
        return lhs;
    }
    return rhs;
}

signed test_loop(signed value) {
    signed result = 0;
    while (value != 0) {
        result += value;
        value--;
    }
    return result;
}
```