### PR TITLE
sh2: support immediate logical operations

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -633,9 +633,9 @@ class Sh2Arch(Arch):
             handle_add if isinstance(a.raw_arg(0), Register) else handle_addi
         )(replace(a, raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)])),
         "sub": lambda a: handle_sub(a.reg(1), a.reg(0)),
-        "and": lambda a: BinaryOp.int(a.reg(1), "&", a.reg(0)),
-        "or": lambda a: handle_or(a.reg(1), a.reg(0)),
-        "xor": lambda a: BinaryOp.int(a.reg(1), "^", a.reg(0)),
+        "and": lambda a: BinaryOp.int(a.reg(1), "&", a.reg_or_imm(0)),
+        "or": lambda a: handle_or(a.reg(1), a.reg_or_imm(0)),
+        "xor": lambda a: BinaryOp.int(a.reg(1), "^", a.reg_or_imm(0)),
     }
 
     instrs_source_dest: InstrMap = {

--- a/tests/end_to_end/sh-immediate-logical/context.c
+++ b/tests/end_to_end/sh-immediate-logical/context.c
@@ -1,0 +1,4 @@
+unsigned test(unsigned value);
+unsigned test_or(unsigned value);
+unsigned test_xor(unsigned value);
+int test_tst(unsigned value);

--- a/tests/end_to_end/sh-immediate-logical/orig.c
+++ b/tests/end_to_end/sh-immediate-logical/orig.c
@@ -1,0 +1,15 @@
+unsigned test(unsigned value) {
+    return value & 0x5A;
+}
+
+unsigned test_or(unsigned value) {
+    return value | 0x5A;
+}
+
+unsigned test_xor(unsigned value) {
+    return value ^ 0x5A;
+}
+
+int test_tst(unsigned value) {
+    return (value & 0x5A) == 0;
+}

--- a/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c --function test_or --function test_xor --function test_tst

--- a/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2-out.c
@@ -1,0 +1,15 @@
+u32 test(u32 value) {
+    return value & 0x5A;
+}
+
+u32 test_or(u32 value) {
+    return value | 0x5A;
+}
+
+u32 test_xor(u32 value) {
+    return value ^ 0x5A;
+}
+
+s32 test_tst(u32 value) {
+    return (value & 0x5A) == 0;
+}

--- a/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-immediate-logical/sh2-gcc-o2.s
@@ -1,0 +1,51 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	mov.l	@r15+,r14
+	rts
+	and	#90,r0
+	.align 2
+	.global	_test_or
+_test_or:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	mov.l	@r15+,r14
+	rts
+	or	#90,r0
+	.align 2
+	.global	_test_xor
+_test_xor:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	mov.l	@r15+,r14
+	rts
+	xor	#90,r0
+	.align 2
+	.global	_test_tst
+_test_tst:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	and	#90,r0
+	tst	r0,r0
+	mov.l	@r15+,r14
+	rts
+	movt	r0


### PR DESCRIPTION
Support for operations like:
```
unsigned test(unsigned value) {
    return value & 0x5A;
}

unsigned test_or(unsigned value) {
    return value | 0x5A;
}

unsigned test_xor(unsigned value) {
    return value ^ 0x5A;
}

int test_tst(unsigned value) {
    return (value & 0x5A) == 0;
}
```