### PR TITLE
Security: Unsafe `sys.path` Modification

### DIFF
--- a/m2c_pycparser/_build_tables.py
+++ b/m2c_pycparser/_build_tables.py
@@ -10,12 +10,17 @@
 # License: BSD
 #-----------------------------------------------------------------
 
-# Insert '.' and '..' as first entries to the search path for modules.
-# Restricted environments like embeddable python do not include the
-# current working directory on startup.
 import importlib
+import os
 import sys
-sys.path[0:0] = ['.', '..']
+
+# Insert the script's directory and its parent at the front of the search path
+# for modules. Restricted environments like embeddable python do not include
+# the current working directory on startup. Use absolute paths to avoid
+# hijacking module imports from untrusted working directories.
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+_parent_dir = os.path.dirname(_script_dir)
+sys.path[0:0] = [_script_dir, _parent_dir]
 
 # Generate c_ast.py
 from _ast_gen import ASTCodeGenerator


### PR DESCRIPTION
## Summary

Security: Unsafe `sys.path` Modification

## Problem

**Severity**: `Medium` | **File**: `m2c_pycparser/_build_tables.py:L13`

In `m2c_pycparser/_build_tables.py`, the script modifies `sys.path` by inserting the current directory (`.`) and parent directory (`..`) at the beginning of the path. If this script is executed in a directory containing maliciously crafted Python files (e.g., `c_ast.py`, `lextab.py`, `yacctab.py`), it could lead to arbitrary code execution by hijacking module imports.

## Solution

Avoid modifying `sys.path` globally, especially by prepending relative directories. If necessary, ensure this script is only run in trusted, controlled environments, or use absolute paths.

## Changes

- `m2c_pycparser/_build_tables.py` (modified)