### PR TITLE
sh2: recognize modulo helper sequences

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -23,6 +23,7 @@ from .asm_pattern import (
     AsmMatcher,
     AsmPattern,
     Replacement,
+    ReplacementPart,
     SimpleAsmPattern,
     make_pattern,
 )
@@ -195,77 +196,41 @@ class DivisionHelperPattern(SimpleAsmPattern):
         return Replacement([delay_slot, division], 3)
 
 
-class ShModuloPattern(AsmPattern):
-    def match(self, matcher: AsmMatcher) -> Optional[Replacement]:
-        body = matcher.input[matcher.index : matcher.index + 11]
-        if len(body) < 10 or not all(isinstance(x, Instruction) for x in body):
-            return None
-        instrs = [x for x in body if isinstance(x, Instruction)]
-        if [x.mnemonic for x in instrs[:9]] != [
-            "mov",
-            "mov.l",
-            "jsr",
-            "mov",
-            "mul.l",
-            "lds.l",
-            "mov.l",
-            "sts",
-            "sub",
-        ]:
-            return None
-        save_lhs, load, call, save_rhs, mul, restore_pr, restore_fp, sts, sub = instrs[
-            :9
-        ]
-        replacement_tail: List[AsmInstruction] = []
-        if instrs[9].mnemonic == "mov" and instrs[9].args == [
-            save_lhs.args[1],
-            Register("r0"),
-        ]:
-            consumed = 10
-        elif (
-            len(instrs) == 11
-            and instrs[9].mnemonic == "rts"
-            and instrs[10].mnemonic == "mov"
-            and instrs[10].args == [save_lhs.args[1], Register("r0")]
-        ):
-            consumed = 11
-            replacement_tail = [
-                AsmInstruction("rts", []),
-                AsmInstruction("nop", []),
-            ]
-        else:
-            return None
-        if (
-            len(save_lhs.args) != 2
-            or not all(isinstance(arg, Register) for arg in save_lhs.args)
-            or len(load.args) != 2
-            or not isinstance(load.args[0], AsmGlobalSymbol)
-            or not isinstance(load.args[1], Register)
-            or len(call.args) != 1
-            or not isinstance(call.args[0], AsmAddressMode)
-            or call.args[0].base != load.args[1]
-            or len(save_rhs.args) != 2
-            or not all(isinstance(arg, Register) for arg in save_rhs.args)
-            or mul.args != [save_rhs.args[1], Register("r0")]
-            or len(sts.args) != 2
-            or sts.args[0] != Register("macl")
-            or sub.args != [sts.args[1], save_lhs.args[1]]
-        ):
-            return None
+class ShModuloPattern(SimpleAsmPattern):
+    pattern = make_pattern(
+        "mov $a, $l",
+        "mov.l _, $t",
+        "jsr @$t",
+        "mov $b, $r",
+        "mul.l $r, $r0",
+        "lds.l @$r15+, $pr",
+        "mov.l @$r15+, $r14",
+        "sts $macl, $m",
+        "sub $m, $l",
+        "rts?",
+        "mov $l, $r0",
+    )
+
+    def replace(self, m: AsmMatch) -> Optional[Replacement]:
+        # Both helpers return the quotient in r0, which the sequence multiplies back
+        # and subtracts to recover the remainder. Testing showed gcc kept the dividend
+        # in a callee-saved register only for the signed helper, which is what we key
+        # on to tell the two apart.
         mnemonic = (
-            "smod.fictive" if save_lhs.args[1] in Sh2Arch.saved_regs else "umod.fictive"
+            "smod.fictive" if m.regs["l"] in Sh2Arch.saved_regs else "umod.fictive"
         )
+        restore_pr, restore_fp = m.body[5], m.body[6]
+        tail: List[ReplacementPart] = []
+        if len(m.body) == 11:
+            tail = [AsmInstruction("rts", []), AsmInstruction("nop", [])]
         return Replacement(
             [
-                AsmInstruction(
-                    mnemonic,
-                    [Register("r0"), save_lhs.args[0], save_rhs.args[0]],
-                ),
-                AsmInstruction(restore_pr.mnemonic, restore_pr.args),
-                AsmInstruction(restore_fp.mnemonic, restore_fp.args),
-                *replacement_tail,
+                AsmInstruction(mnemonic, [Register("r0"), m.regs["a"], m.regs["b"]]),
+                restore_pr,
+                restore_fp,
+                *tail,
             ],
-            consumed,
+            len(m.body),
         )
 
 

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, List, Optional
 
 from .error import DecompFailure
 from .options import Target
-from .asm_file import AsmSymbolicData
+from .asm_file import AsmData, AsmSymbolicData
 from .asm_instruction import (
     Argument,
     AsmAddressMode,
@@ -22,8 +22,8 @@ from .asm_pattern import (
     AsmMatch,
     AsmMatcher,
     AsmPattern,
+    BodyPart,
     Replacement,
-    ReplacementPart,
     SimpleAsmPattern,
     make_pattern,
 )
@@ -55,6 +55,7 @@ from .translate import (
 
 from .evaluate import (
     condition_from_expr,
+    fold_divmod,
     fold_mul_chains,
     fold_shift_right,
     handle_add,
@@ -166,72 +167,57 @@ class Sh2AddrModeWritebackPattern(AsmPattern):
         )
 
 
-class DivisionHelperPattern(SimpleAsmPattern):
-    pattern = make_pattern("mov.l _, $t", "jsr @$t", "*")
-
-    def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        load = m.body[0]
-        delay_slot = m.wildcard_items[0]
-        assert isinstance(load, Instruction)
-        assert isinstance(load.args[0], AsmGlobalSymbol)
-        if not isinstance(delay_slot, Instruction):
-            return None
-
-        entry = m.asm_data.values.get(load.args[0].symbol_name)
-        if entry is None:
-            return None
-        target = entry.data_at_offset(0, 4)
-        if not isinstance(target, AsmSymbolicData):
-            return None
-        target_name = target.as_symbol_without_addend()
-        if target_name is None:
-            return None
-        mnemonic = {
-            "___sdivsi3": "sdiv.fictive",
-            "___udivsi3": "udiv.fictive",
-        }.get(target_name)
-        if mnemonic is None:
-            return None
-        division = AsmInstruction(mnemonic, [Register("r4"), Register("r5")])
-        return Replacement([delay_slot, division], 3)
+def literal_pool_target(asm_data: AsmData, load: BodyPart) -> Optional[str]:
+    """Return the symbol a `mov.l <label>, rN` literal pool load points at."""
+    if not isinstance(load, Instruction) or not isinstance(
+        load.args[0], AsmGlobalSymbol
+    ):
+        return None
+    entry = asm_data.values.get(load.args[0].symbol_name)
+    if entry is None:
+        return None
+    target = entry.data_at_offset(0, 4)
+    if not isinstance(target, AsmSymbolicData):
+        return None
+    return target.as_symbol_without_addend()
 
 
-class ShModuloPattern(SimpleAsmPattern):
-    pattern = make_pattern(
-        "mov $a, $l",
-        "mov.l _, $t",
-        "jsr @$t",
-        "mov $b, $r",
-        "mul.l $r, $r0",
-        "lds.l @$r15+, $pr",
-        "mov.l @$r15+, $r14",
-        "sts $macl, $m",
-        "sub $m, $l",
-        "rts?",
-        "mov $l, $r0",
-    )
+def sh_sub(lhs: Expression, rhs: Expression) -> Expression:
+    """Subtract, recognizing the `x - (x / y) * y` shape gcc emits for modulo."""
+    expr = handle_sub(lhs, rhs)
+    if isinstance(expr, BinaryOp):
+        return fold_divmod(expr)
+    return expr
 
-    def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        # Both helpers return the quotient in r0, which the sequence multiplies back
-        # and subtracts to recover the remainder. Testing showed gcc kept the dividend
-        # in a callee-saved register only for the signed helper, which is what we key
-        # on to tell the two apart.
-        mnemonic = (
-            "smod.fictive" if m.regs["l"] in Sh2Arch.saved_regs else "umod.fictive"
-        )
-        restore_pr, restore_fp = m.body[5], m.body[6]
-        tail: List[ReplacementPart] = []
-        if len(m.body) == 11:
-            tail = [AsmInstruction("rts", []), AsmInstruction("nop", [])]
-        return Replacement(
-            [
-                AsmInstruction(mnemonic, [Register("r0"), m.regs["a"], m.regs["b"]]),
-                restore_pr,
-                restore_fp,
-                *tail,
-            ],
-            len(m.body),
-        )
+
+class DivisionHelperPattern(AsmPattern):
+    # gcc normally emits the literal pool load right before the call, but the
+    # scheduler is free to slot unrelated instructions into the gap, so allow a
+    # couple. Matching is still safe because the pool entry has to resolve to a
+    # known division helper.
+    patterns = [
+        make_pattern("mov.l _, $t", "jsr @$t", "*"),
+        make_pattern("mov.l _, $t", "*", "jsr @$t", "*"),
+        make_pattern("mov.l _, $t", "*", "*", "jsr @$t", "*"),
+    ]
+
+    def match(self, matcher: AsmMatcher) -> Optional[Replacement]:
+        for pattern in self.patterns:
+            m = matcher.try_match(pattern)
+            if m is None:
+                continue
+            mnemonic = {
+                "___sdivsi3": "sdiv.fictive",
+                "___udivsi3": "udiv.fictive",
+            }.get(literal_pool_target(m.asm_data, m.body[0]) or "")
+            if mnemonic is None:
+                continue
+            scheduled = m.wildcard_items
+            if not all(isinstance(x, Instruction) for x in scheduled):
+                continue
+            division = AsmInstruction(mnemonic, [Register("r4"), Register("r5")])
+            return Replacement([*scheduled, division], len(m.body))
+        return None
 
 
 class Sh2Arch(Arch):
@@ -601,21 +587,6 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 Register("r0"), op(a.reg(0), "/", a.reg(1))
             )
-        elif mnemonic in ("smod.fictive", "umod.fictive"):
-            assert (
-                len(args) == 3
-                and isinstance(args[0], Register)
-                and isinstance(args[1], Register)
-                and isinstance(args[2], Register)
-            )
-            inputs = [args[1], args[2]]
-            outputs = [args[0]]
-            eval_fn = lambda s, a: s.set_reg(
-                a.reg_ref(0),
-                (BinaryOp.sint if mnemonic == "smod.fictive" else BinaryOp.uint)(
-                    a.reg(1), "%", a.reg(2)
-                ),
-            )
         elif mnemonic == "tablejmp.fictive":
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []
@@ -686,7 +657,7 @@ class Sh2Arch(Arch):
         "add": lambda a: (
             handle_add if isinstance(a.raw_arg(0), Register) else handle_addi
         )(replace(a, raw_args=[a.raw_arg(1), a.raw_arg(1), a.raw_arg(0)])),
-        "sub": lambda a: handle_sub(a.reg(1), a.reg(0)),
+        "sub": lambda a: sh_sub(a.reg(1), a.reg(0)),
         "and": lambda a: BinaryOp.int(a.reg(1), "&", a.reg_or_imm(0)),
         "or": lambda a: handle_or(a.reg(1), a.reg_or_imm(0)),
         "xor": lambda a: BinaryOp.int(a.reg(1), "^", a.reg_or_imm(0)),
@@ -740,7 +711,6 @@ class Sh2Arch(Arch):
     }
 
     asm_patterns = [
-        ShModuloPattern(),
         DivisionHelperPattern(),
         JumpTablePattern(),
         Sh2AddrModeWritebackPattern(),

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -195,6 +195,80 @@ class DivisionHelperPattern(SimpleAsmPattern):
         return Replacement([delay_slot, division], 3)
 
 
+class ShModuloPattern(AsmPattern):
+    def match(self, matcher: AsmMatcher) -> Optional[Replacement]:
+        body = matcher.input[matcher.index : matcher.index + 11]
+        if len(body) < 10 or not all(isinstance(x, Instruction) for x in body):
+            return None
+        instrs = [x for x in body if isinstance(x, Instruction)]
+        if [x.mnemonic for x in instrs[:9]] != [
+            "mov",
+            "mov.l",
+            "jsr",
+            "mov",
+            "mul.l",
+            "lds.l",
+            "mov.l",
+            "sts",
+            "sub",
+        ]:
+            return None
+        save_lhs, load, call, save_rhs, mul, restore_pr, restore_fp, sts, sub = instrs[
+            :9
+        ]
+        replacement_tail: List[AsmInstruction] = []
+        if instrs[9].mnemonic == "mov" and instrs[9].args == [
+            save_lhs.args[1],
+            Register("r0"),
+        ]:
+            consumed = 10
+        elif (
+            len(instrs) == 11
+            and instrs[9].mnemonic == "rts"
+            and instrs[10].mnemonic == "mov"
+            and instrs[10].args == [save_lhs.args[1], Register("r0")]
+        ):
+            consumed = 11
+            replacement_tail = [
+                AsmInstruction("rts", []),
+                AsmInstruction("nop", []),
+            ]
+        else:
+            return None
+        if (
+            len(save_lhs.args) != 2
+            or not all(isinstance(arg, Register) for arg in save_lhs.args)
+            or len(load.args) != 2
+            or not isinstance(load.args[0], AsmGlobalSymbol)
+            or not isinstance(load.args[1], Register)
+            or len(call.args) != 1
+            or not isinstance(call.args[0], AsmAddressMode)
+            or call.args[0].base != load.args[1]
+            or len(save_rhs.args) != 2
+            or not all(isinstance(arg, Register) for arg in save_rhs.args)
+            or mul.args != [save_rhs.args[1], Register("r0")]
+            or len(sts.args) != 2
+            or sts.args[0] != Register("macl")
+            or sub.args != [sts.args[1], save_lhs.args[1]]
+        ):
+            return None
+        mnemonic = (
+            "smod.fictive" if save_lhs.args[1] in Sh2Arch.saved_regs else "umod.fictive"
+        )
+        return Replacement(
+            [
+                AsmInstruction(
+                    mnemonic,
+                    [Register("r0"), save_lhs.args[0], save_rhs.args[0]],
+                ),
+                AsmInstruction(restore_pr.mnemonic, restore_pr.args),
+                AsmInstruction(restore_fp.mnemonic, restore_fp.args),
+                *replacement_tail,
+            ],
+            consumed,
+        )
+
+
 class Sh2Arch(Arch):
     arch = Target.ArchEnum.SH2
 
@@ -562,6 +636,21 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 Register("r0"), op(a.reg(0), "/", a.reg(1))
             )
+        elif mnemonic in ("smod.fictive", "umod.fictive"):
+            assert (
+                len(args) == 3
+                and isinstance(args[0], Register)
+                and isinstance(args[1], Register)
+                and isinstance(args[2], Register)
+            )
+            inputs = [args[1], args[2]]
+            outputs = [args[0]]
+            eval_fn = lambda s, a: s.set_reg(
+                a.reg_ref(0),
+                (BinaryOp.sint if mnemonic == "smod.fictive" else BinaryOp.uint)(
+                    a.reg(1), "%", a.reg(2)
+                ),
+            )
         elif mnemonic == "tablejmp.fictive":
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []
@@ -686,6 +775,7 @@ class Sh2Arch(Arch):
     }
 
     asm_patterns = [
+        ShModuloPattern(),
         DivisionHelperPattern(),
         JumpTablePattern(),
         Sh2AddrModeWritebackPattern(),

--- a/tests/end_to_end/sh-modulo-helpers/context.c
+++ b/tests/end_to_end/sh-modulo-helpers/context.c
@@ -2,3 +2,10 @@ signed test(signed lhs, signed rhs);
 unsigned test_unsigned(unsigned lhs, unsigned rhs);
 signed __sdivsi3(signed lhs, signed rhs);
 unsigned __udivsi3(unsigned lhs, unsigned rhs);
+
+/* Real-world modulo shapes from a corpus; see manual.s. */
+signed mod_extu_delay(signed lhs, signed rhs);
+signed mod_split_dividend(signed lhs, signed rhs);
+signed mod_feeds_multiply(signed lhs, signed rhs);
+unsigned mod_moved_quotient(unsigned lhs, unsigned rhs);
+unsigned mod_interleaved(unsigned lhs, unsigned rhs);

--- a/tests/end_to_end/sh-modulo-helpers/context.c
+++ b/tests/end_to_end/sh-modulo-helpers/context.c
@@ -1,0 +1,4 @@
+signed test(signed lhs, signed rhs);
+unsigned test_unsigned(unsigned lhs, unsigned rhs);
+signed __sdivsi3(signed lhs, signed rhs);
+unsigned __udivsi3(unsigned lhs, unsigned rhs);

--- a/tests/end_to_end/sh-modulo-helpers/manual-flags.txt
+++ b/tests/end_to_end/sh-modulo-helpers/manual-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c --function mod_extu_delay --function mod_split_dividend --function mod_feeds_multiply --function mod_moved_quotient --function mod_interleaved

--- a/tests/end_to_end/sh-modulo-helpers/manual-out.c
+++ b/tests/end_to_end/sh-modulo-helpers/manual-out.c
@@ -1,0 +1,23 @@
+s32 test(s32 lhs, s32 rhs) {
+    return (lhs % rhs) + 1;
+}
+
+s32 mod_extu_delay(s32 lhs, s32 rhs) {
+    return lhs % (u16) rhs;
+}
+
+s32 mod_split_dividend(s32 lhs, s32 rhs) {
+    return lhs % (u16) rhs;
+}
+
+s32 mod_feeds_multiply(s32 lhs, s32 rhs) {
+    return (lhs % (u16) rhs) * lhs;
+}
+
+u32 mod_moved_quotient(u32 lhs, u32 rhs) {
+    return (lhs % rhs) + 1;
+}
+
+u32 mod_interleaved(u32 lhs, u32 rhs) {
+    return lhs % rhs;
+}

--- a/tests/end_to_end/sh-modulo-helpers/manual.s
+++ b/tests/end_to_end/sh-modulo-helpers/manual.s
@@ -1,0 +1,177 @@
+	.file	"manual.s"
+	.text
+	.align 2
+
+! The quotient is used straight out of r0, with no intervening move, and the
+! remainder feeds an add rather than being returned.
+	.global	_test
+_test:
+	sts.l	pr,@-r15
+	mov.l	r8,@-r15
+	mov	r4,r8
+	mov	r5,r6
+	mov	r8,r4
+	mov.l	L100,r7
+	jsr	@r7
+	mov	r6,r5
+	mul.l	r6,r0
+	sts	macl,r1
+	sub	r1,r8
+	add	#1,r8
+	mov	r8,r0
+	mov.l	@r15+,r8
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L100:
+	.long	___sdivsi3
+
+	.align 2
+! An `extu.w` sits between the literal pool load and the jsr, so even
+	.global	_mod_extu_delay
+_mod_extu_delay:
+	sts.l	pr,@-r15
+	mov	r4,r7
+	mov	r5,r1
+	mov	r7,r4
+	mov.l	L101,r0
+	extu.w	r1,r6
+	jsr	@r0
+	mov	r6,r5
+	mov	r0,r5
+	mul.l	r6,r5
+	sts	macl,r1
+	sub	r1,r7
+	mov	r7,r0
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L101:
+	.long	___sdivsi3
+
+	.align 2
+! The dividend is loaded into r8 *after* the multiply, between `mul.l` and
+! `sts`, so the run is not contiguous
+	.global	_mod_split_dividend
+_mod_split_dividend:
+	sts.l	pr,@-r15
+	mov.l	r8,@-r15
+	mov.l	r11,@-r15
+	mov	r4,r11
+	mov	r5,r6
+	mov	r11,r4
+	mov.l	L102,r0
+	extu.w	r6,r6
+	jsr	@r0
+	mov	r6,r5
+	mov	r0,r7
+	mul.l	r6,r7
+	mov	r11,r8
+	sts	macl,r1
+	sub	r1,r8
+	mov	r8,r0
+	mov.l	@r15+,r11
+	mov.l	@r15+,r8
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L102:
+	.long	___sdivsi3
+
+	.align 2
+! The remainder feeds a further multiply instead of being returned.
+	.global	_mod_feeds_multiply
+_mod_feeds_multiply:
+	sts.l	pr,@-r15
+	mov.l	r13,@-r15
+	mov	r4,r13
+	mov	r5,r7
+	mov	r13,r4
+	mov.l	L103,r0
+	extu.w	r7,r7
+	jsr	@r0
+	mov	r7,r5
+	mov	r0,r5
+	mul.l	r7,r5
+	mov	r13,r4
+	sts	macl,r1
+	sub	r1,r4
+	mov	r4,r1
+	mul.l	r13,r1
+	sts	macl,r0
+	mov.l	@r15+,r13
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L103:
+	.long	___sdivsi3
+
+	.align 2
+! quotient moved out of r0 before the multiply.
+	.global	_mod_moved_quotient
+_mod_moved_quotient:
+	sts.l	pr,@-r15
+	mov.l	r9,@-r15
+	mov	r4,r7
+	mov	r5,r9
+	mov	r7,r4
+	mov.l	L104,r0
+	jsr	@r0
+	mov	r9,r5
+	mov	r0,r5
+	mul.l	r9,r5
+	sts	macl,r1
+	sub	r1,r7
+	mov	r7,r0
+	add	#1,r0
+	mov.l	@r15+,r9
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L104:
+	.long	___udivsi3
+
+	.align 2
+! Two modulo sequences interleaved by the scheduler: the `sub` completing the
+! first one is placed in the delay slot of the second one's call.
+	.global	_mod_interleaved
+_mod_interleaved:
+	sts.l	pr,@-r15
+	mov.l	r9,@-r15
+	mov.l	r11,@-r15
+	mov.l	r13,@-r15
+	mov	r4,r13
+	mov	r5,r9
+	mov	r4,r11
+	mov	r13,r4
+	mov.l	L105,r0
+	jsr	@r0
+	mov	r13,r5
+	mov	r0,r7
+	mov	r13,r4
+	mul.l	r13,r7
+	mov	r9,r5
+	mov.l	L105,r0
+	sts	macl,r1
+	mov	r11,r7
+	jsr	@r0
+	sub	r1,r7
+	mov	r0,r5
+	mul.l	r9,r5
+	mov	r13,r0
+	sts	macl,r1
+	sub	r1,r0
+	mov.l	@r15+,r13
+	mov.l	@r15+,r11
+	mov.l	@r15+,r9
+	lds.l	@r15+,pr
+	rts
+	nop
+	.align 2
+L105:
+	.long	___udivsi3

--- a/tests/end_to_end/sh-modulo-helpers/orig.c
+++ b/tests/end_to_end/sh-modulo-helpers/orig.c
@@ -1,0 +1,7 @@
+signed test(signed lhs, signed rhs) {
+    return lhs % rhs;
+}
+
+unsigned test_unsigned(unsigned lhs, unsigned rhs) {
+    return lhs % rhs;
+}

--- a/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c --function test_unsigned

--- a/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2-out.c
@@ -1,0 +1,7 @@
+s32 test(s32 lhs, s32 rhs) {
+    return lhs % rhs;
+}
+
+u32 test_unsigned(u32 lhs, u32 rhs) {
+    return lhs % rhs;
+}

--- a/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-modulo-helpers/sh2-gcc-o2.s
@@ -1,0 +1,57 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r8,@-r15
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov	r4,r8
+	mov.l	L2,r6
+	jsr	@r6
+	mov	r5,r7
+	mul.l	r7,r0
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	sts	macl,r1
+	sub	r1,r8
+	mov	r8,r0
+	rts
+	mov.l	@r15+,r8
+L3:
+	.align 2
+L2:
+	.long	___sdivsi3
+	.align 2
+	.global	_test_unsigned
+_test_unsigned:
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov	r4,r3
+	mov.l	L5,r2
+	jsr	@r2
+	mov	r5,r1
+	mul.l	r1,r0
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	sts	macl,r1
+	sub	r1,r3
+	rts
+	mov	r3,r0
+L6:
+	.align 2
+L5:
+	.long	___udivsi3


### PR DESCRIPTION
This adds `ShModuloPattern` to help with
```
signed test(signed lhs, signed rhs) {
    return lhs % rhs;
}

unsigned test_unsigned(unsigned lhs, unsigned rhs) {
    return lhs % rhs;
}
```
and recognize calls to `___sdivsi3` and `___udivsi3`