### PR TITLE
sh2: support positive comparisons

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -510,6 +510,18 @@ class Sh2Arch(Arch):
                     BinaryOp.icmp(value, "==", Literal(0)),
                 )
 
+        elif mnemonic in ("cmp/pl", "cmp/pz"):
+            assert len(args) == 1 and isinstance(args[0], Register)
+            inputs = [args[0]]
+            outputs = [Register("condition_bit")]
+            eval_fn = lambda s, a: s.set_reg(
+                Register("condition_bit"),
+                BinaryOp.scmp(
+                    a.reg(0),
+                    ">" if mnemonic == "cmp/pl" else ">=",
+                    Literal(0),
+                ),
+            )
         elif mnemonic in ("bf.s", "bt.s"):
             assert len(args) == 1
             inputs = [Register("condition_bit")]

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -516,11 +516,7 @@ class Sh2Arch(Arch):
             outputs = [Register("condition_bit")]
             eval_fn = lambda s, a: s.set_reg(
                 Register("condition_bit"),
-                BinaryOp.scmp(
-                    a.reg(0),
-                    ">" if mnemonic == "cmp/pl" else ">=",
-                    Literal(0),
-                ),
+                cls.instrs_compare_zero[mnemonic](a),
             )
         elif mnemonic in ("bf.s", "bt.s"):
             assert len(args) == 1
@@ -593,21 +589,10 @@ class Sh2Arch(Arch):
             if isinstance(args[0], Register):
                 inputs.insert(0, args[0])
             outputs = [Register("condition_bit")]
-
-            def eval_fn(s: NodeState, a: InstrArgs) -> None:
-                lhs = a.reg(1)
-                rhs = a.reg_or_imm(0)
-                if mnemonic == "cmp/eq":
-                    condition = BinaryOp.icmp(lhs, "==", rhs)
-                elif mnemonic == "cmp/ge":
-                    condition = BinaryOp.scmp(lhs, ">=", rhs)
-                elif mnemonic == "cmp/gt":
-                    condition = BinaryOp.scmp(lhs, ">", rhs)
-                elif mnemonic == "cmp/hs":
-                    condition = BinaryOp.ucmp(lhs, ">=", rhs)
-                else:
-                    condition = BinaryOp.ucmp(lhs, ">", rhs)
-                s.set_reg(Register("condition_bit"), condition)
+            eval_fn = lambda s, a: s.set_reg(
+                Register("condition_bit"),
+                cls.instrs_compare[mnemonic](a),
+            )
 
         elif mnemonic == "movt":
             assert len(args) == 1 and isinstance(args[0], Register)
@@ -639,6 +624,19 @@ class Sh2Arch(Arch):
             is_store=is_store,
             has_delay_slot=has_delay_slot,
         )
+
+    instrs_compare_zero: InstrMap = {
+        "cmp/pl": lambda a: BinaryOp.scmp(a.reg(0), ">", Literal(0)),
+        "cmp/pz": lambda a: BinaryOp.scmp(a.reg(0), ">=", Literal(0)),
+    }
+
+    instrs_compare: InstrMap = {
+        "cmp/eq": lambda a: BinaryOp.icmp(a.reg(1), "==", a.reg_or_imm(0)),
+        "cmp/ge": lambda a: BinaryOp.scmp(a.reg(1), ">=", a.reg_or_imm(0)),
+        "cmp/gt": lambda a: BinaryOp.scmp(a.reg(1), ">", a.reg_or_imm(0)),
+        "cmp/hi": lambda a: BinaryOp.ucmp(a.reg(1), ">", a.reg_or_imm(0)),
+        "cmp/hs": lambda a: BinaryOp.ucmp(a.reg(1), ">=", a.reg_or_imm(0)),
+    }
 
     instrs_read_modify_write: InstrMap = {
         # sh2 format is src, dst

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -510,13 +510,12 @@ class Sh2Arch(Arch):
                     BinaryOp.icmp(value, "==", Literal(0)),
                 )
 
-        elif mnemonic in ("cmp/pl", "cmp/pz"):
-            assert len(args) == 1 and isinstance(args[0], Register)
-            inputs = [args[0]]
+        elif mnemonic in cls.instrs_compare:
+            inputs = [arg for arg in args if isinstance(arg, Register)]
             outputs = [Register("condition_bit")]
             eval_fn = lambda s, a: s.set_reg(
                 Register("condition_bit"),
-                cls.instrs_compare_zero[mnemonic](a),
+                cls.instrs_compare[mnemonic](a),
             )
         elif mnemonic in ("bf.s", "bt.s"):
             assert len(args) == 1
@@ -583,17 +582,6 @@ class Sh2Arch(Arch):
             is_conditional = True
             has_delay_slot = True
             eval_fn = lambda s, a: s.set_switch_expr(a.reg(0), just_index=True)
-        elif mnemonic in ("cmp/eq", "cmp/ge", "cmp/gt", "cmp/hi", "cmp/hs"):
-            assert len(args) == 2 and isinstance(args[1], Register)
-            inputs = [args[1]]
-            if isinstance(args[0], Register):
-                inputs.insert(0, args[0])
-            outputs = [Register("condition_bit")]
-            eval_fn = lambda s, a: s.set_reg(
-                Register("condition_bit"),
-                cls.instrs_compare[mnemonic](a),
-            )
-
         elif mnemonic == "movt":
             assert len(args) == 1 and isinstance(args[0], Register)
             inputs = [Register("condition_bit")]
@@ -625,12 +613,9 @@ class Sh2Arch(Arch):
             has_delay_slot=has_delay_slot,
         )
 
-    instrs_compare_zero: InstrMap = {
+    instrs_compare: InstrMap = {
         "cmp/pl": lambda a: BinaryOp.scmp(a.reg(0), ">", Literal(0)),
         "cmp/pz": lambda a: BinaryOp.scmp(a.reg(0), ">=", Literal(0)),
-    }
-
-    instrs_compare: InstrMap = {
         "cmp/eq": lambda a: BinaryOp.icmp(a.reg(1), "==", a.reg_or_imm(0)),
         "cmp/ge": lambda a: BinaryOp.scmp(a.reg(1), ">=", a.reg_or_imm(0)),
         "cmp/gt": lambda a: BinaryOp.scmp(a.reg(1), ">", a.reg_or_imm(0)),

--- a/tests/end_to_end/sh-compare-positive/orig.c
+++ b/tests/end_to_end/sh-compare-positive/orig.c
@@ -1,0 +1,9 @@
+signed test(signed value) {
+    if (value < 0) {
+        return -1;
+    }
+    if (value > 0) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/end_to_end/sh-compare-positive/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-compare-positive/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-compare-positive/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-compare-positive/sh2-gcc-o2-out.c
@@ -1,0 +1,12 @@
+s32 test(s32 arg0) {
+    s32 var_r0;
+
+    if (arg0 < 0) {
+        return -1;
+    }
+    var_r0 = 1;
+    if (arg0 <= 0) {
+        var_r0 = 0;
+    }
+    return var_r0;
+}

--- a/tests/end_to_end/sh-compare-positive/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-compare-positive/sh2-gcc-o2.s
@@ -1,0 +1,32 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	cmp/pz	r4
+	bt.s	L2
+	mov	r15,r14
+	bra	L4
+	mov	#-1,r0
+L2:
+	cmp/pl	r4
+	bt.s	L3
+	mov	#1,r0
+	mov	#0,r0
+L3:
+L4:
+	mov	r14,r15
+	rts
+	mov.l	@r15+,r14


### PR DESCRIPTION
This adds the `cmp/pl` and `cmp/pz` instructions which doc`If Rn > 0, 1 → T` and `If Rn ≥ 0, 1 → T` respectively. This allows some additional types of branching like
```
signed test(signed value) {
    if (value < 0) {
        return -1;
    }
    if (value > 0) {
        return 1;
    }
    return 0;
}
```
Disclosure: AI assistance was used while developing and reviewing this change. I verified the implementation and tests myself.