### PR TITLE
sh2: evaluate mova addresses

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -313,6 +313,14 @@ class Sh2Arch(Arch):
                 assert isinstance(args[0], AsmLiteral)
                 eval_fn = lambda s, a: s.set_reg(a.reg_ref(1), a.s8_imm(0))
 
+        elif mnemonic == "mova":
+            assert (
+                len(args) == 2
+                and isinstance(args[0], AsmGlobalSymbol)
+                and args[1] == Register("r0")
+            )
+            outputs = [Register("r0")]
+            eval_fn = lambda s, a: s.set_reg(Register("r0"), a.full_imm(0))
         elif mnemonic in ("mov.b", "mov.l", "mov.w"):
             assert len(args) == 2
             if isinstance(args[0], Register):

--- a/tests/end_to_end/sh-mova/context.c
+++ b/tests/end_to_end/sh-mova/context.c
@@ -1,0 +1,1 @@
+void *test(void);

--- a/tests/end_to_end/sh-mova/context.c
+++ b/tests/end_to_end/sh-mova/context.c
@@ -1,1 +1,0 @@
-void *test(void);

--- a/tests/end_to_end/sh-mova/manual-flags.txt
+++ b/tests/end_to_end/sh-mova/manual-flags.txt
@@ -1,0 +1,1 @@
+--context context.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-mova/manual-flags.txt
+++ b/tests/end_to_end/sh-mova/manual-flags.txt
@@ -1,1 +1,1 @@
---context context.c --target sh2-gcc-c
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-mova/manual-out.c
+++ b/tests/end_to_end/sh-mova/manual-out.c
@@ -1,0 +1,5 @@
+? literal();                                        /* static */
+
+void *test(void) {
+    return literal;
+}

--- a/tests/end_to_end/sh-mova/manual-out.c
+++ b/tests/end_to_end/sh-mova/manual-out.c
@@ -1,5 +1,3 @@
-? literal();                                        /* static */
-
-void *test(void) {
-    return literal;
+s32 test(void) {
+    return 0;
 }

--- a/tests/end_to_end/sh-mova/manual.s
+++ b/tests/end_to_end/sh-mova/manual.s
@@ -1,0 +1,7 @@
+glabel test
+mova literal, r0
+rts
+nop
+.align 2
+literal:
+.long 0

--- a/tests/end_to_end/sh-mova/manual.s
+++ b/tests/end_to_end/sh-mova/manual.s
@@ -1,7 +1,8 @@
 glabel test
-mova literal, r0
+mova L1, r0
+mov.l @r0, r0
 rts
 nop
 .align 2
-literal:
+L1:
 .long 0


### PR DESCRIPTION
Implements `MOVA @(disp,PC),R0`. I don't think my version of gcc can emit this outside of a jump table so this has a manual test.
Disclosure: AI assistance was used during development.