### PR TITLE
sh2: support subc, shll

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -126,6 +126,20 @@ class NegateTPattern(SimpleAsmPattern):
         return Replacement([AsmInstruction("negatet.fictive", [])], len(m.body))
 
 
+class SubcSelfPattern(SimpleAsmPattern):
+    pattern = make_pattern("subc $r, $r")
+
+    def replace(self, m: AsmMatch) -> Replacement:
+        reg = m.regs["r"]
+        return Replacement(
+            [
+                AsmInstruction("movt", [reg]),
+                AsmInstruction("neg", [reg, reg]),
+            ],
+            len(m.body),
+        )
+
+
 class Sh2AddrModeWritebackPattern(AsmPattern):
     """Replace writebacks in mov address modes by separate add instructions."""
 
@@ -493,19 +507,6 @@ class Sh2Arch(Arch):
                 s.set_reg(Register("macl"), Literal(0))
                 s.set_reg(Register("mach"), Literal(0))
 
-        elif (
-            mnemonic == "subc"
-            and len(args) == 2
-            and isinstance(args[0], Register)
-            and args[0] == args[1]
-        ):
-            inputs = [Register("condition_bit")]
-            outputs = [args[1]]
-
-            def eval_fn(s: NodeState, a: InstrArgs) -> None:
-                carry = a.regs[Register("condition_bit")]
-                s.set_reg(a.reg_ref(1), UnaryOp.sint("-", carry))
-
         elif mnemonic in cls.instrs_shift:
             assert len(args) == 1 and isinstance(args[0], Register)
             inputs = [args[0]]
@@ -778,6 +779,7 @@ class Sh2Arch(Arch):
         JumpTablePattern(),
         Sh2AddrModeWritebackPattern(),
         NegateTPattern(),
+        SubcSelfPattern(),
     ]
 
     def arg_name(self, loc: ArgLoc) -> str:

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -499,13 +499,12 @@ class Sh2Arch(Arch):
             and isinstance(args[0], Register)
             and args[0] == args[1]
         ):
-            inputs = [args[0], Register("condition_bit")]
-            outputs = [args[1], Register("condition_bit")]
+            inputs = [Register("condition_bit")]
+            outputs = [args[1]]
 
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
                 carry = a.regs[Register("condition_bit")]
                 s.set_reg(a.reg_ref(1), UnaryOp.sint("-", carry))
-                s.set_reg(Register("condition_bit"), carry)
 
         elif mnemonic in cls.instrs_shift:
             assert len(args) == 1 and isinstance(args[0], Register)

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -493,11 +493,25 @@ class Sh2Arch(Arch):
                 s.set_reg(Register("macl"), Literal(0))
                 s.set_reg(Register("mach"), Literal(0))
 
+        elif (
+            mnemonic == "subc"
+            and len(args) == 2
+            and isinstance(args[0], Register)
+            and args[0] == args[1]
+        ):
+            inputs = [args[0], Register("condition_bit")]
+            outputs = [args[1], Register("condition_bit")]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                carry = a.regs[Register("condition_bit")]
+                s.set_reg(a.reg_ref(1), UnaryOp.sint("-", carry))
+                s.set_reg(Register("condition_bit"), carry)
+
         elif mnemonic in cls.instrs_shift:
             assert len(args) == 1 and isinstance(args[0], Register)
             inputs = [args[0]]
             outputs = [args[0]]
-            if mnemonic in ("shlr", "shar", "rotl", "rotr"):
+            if mnemonic in ("shll", "shlr", "shar", "rotl", "rotr"):
                 outputs.append(Register("condition_bit"))
 
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
@@ -506,7 +520,7 @@ class Sh2Arch(Arch):
                     carry = BinaryOp.intptr(original, "&", Literal(1))
                 else:
                     carry = BinaryOp.uint(original, ">>", Literal(31))
-                if mnemonic in ("shlr", "shar", "rotl", "rotr"):
+                if mnemonic in ("shll", "shlr", "shar", "rotl", "rotr"):
                     s.set_reg(Register("condition_bit"), carry)
                 s.set_reg(a.reg_ref(0), cls.instrs_shift[mnemonic](a))
 
@@ -731,6 +745,9 @@ class Sh2Arch(Arch):
     }
 
     instrs_shift: InstrMap = {
+        "shll": lambda a: fold_mul_chains(
+            BinaryOp.int(a.reg(0), "<<", Literal(1)), allow_sll_chains=True
+        ),
         "shlr": lambda a: fold_shift_right(a.reg(0), 1, signed=False),
         "shar": lambda a: fold_shift_right(a.reg(0), 1, signed=True),
         "shll2": lambda a: fold_mul_chains(

--- a/tests/end_to_end/sh-sign-mask/orig.c
+++ b/tests/end_to_end/sh-sign-mask/orig.c
@@ -1,0 +1,3 @@
+signed test(signed value) {
+    return value >> 31;
+}

--- a/tests/end_to_end/sh-sign-mask/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-sign-mask/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-sign-mask/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-sign-mask/sh2-gcc-o2-out.c
@@ -1,0 +1,3 @@
+s32 test(u32 arg0) {
+    return -(s32) (arg0 >> 0x1FU);
+}

--- a/tests/end_to_end/sh-sign-mask/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-sign-mask/sh2-gcc-o2.s
@@ -1,0 +1,23 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	mov	r4,r0
+	shll	r0
+	subc	r0,r0
+	rts
+	mov.l	@r15+,r14


### PR DESCRIPTION
Fixes this situation
```
  s32 test(s32 arg0) {
      M2C_ERROR(/* unknown instruction: shll $r0 */);
      M2C_ERROR(/* unknown instruction: subc $r0, $r0 */);
      return arg0;
  }
```
 Disclosure: AI assistance was used during development.