### PR TITLE
sh2: support double-width multiply

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -55,6 +55,7 @@ from .translate import (
 from .evaluate import (
     condition_from_expr,
     fn_op,
+    fold_divmod,
     fold_mul_chains,
     fold_shift_right,
     handle_add,
@@ -507,33 +508,16 @@ class Sh2Arch(Arch):
             )
             inputs = [args[0], args[1]]
             outputs = [Register("mach"), Register("macl")]
-            signed = mnemonic == "dmuls.l"
+            high_op = "MULT_HI" if mnemonic == "dmuls.l" else "MULTU_HI"
 
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
-                # 64-bit, mach has high part, macl has low part
-                operand_type = Type.s32() if signed else Type.u32()
-                product_type = Type.s64() if signed else Type.u64()
-                lhs = as_type(a.reg(1), operand_type, silent=True)
-                rhs = as_type(a.reg(0), operand_type, silent=True)
-                product = BinaryOp(
-                    as_type(lhs, product_type, silent=False),
-                    "*",
-                    as_type(rhs, product_type, silent=False),
-                    type=product_type,
-                )
-                high = BinaryOp(
-                    product,
-                    ">>",
-                    Literal(32),
-                    type=product_type,
-                )
                 s.set_reg(
                     Register("mach"),
-                    as_type(high, operand_type, silent=True),
+                    fold_divmod(BinaryOp.int(a.reg(1), high_op, a.reg(0))),
                 )
                 s.set_reg(
                     Register("macl"),
-                    as_type(product, Type.u32(), silent=True),
+                    BinaryOp.int(a.reg(1), "*", a.reg(0)),
                 )
 
         elif mnemonic == "clrmac":

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -499,6 +499,43 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 Register("macl"), cls.instrs_multiply[mnemonic](a)
             )
+        elif mnemonic in ("dmuls.l", "dmulu.l"):
+            assert (
+                len(args) == 2
+                and isinstance(args[0], Register)
+                and isinstance(args[1], Register)
+            )
+            inputs = [args[0], args[1]]
+            outputs = [Register("mach"), Register("macl")]
+            signed = mnemonic == "dmuls.l"
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                # 64-bit, mach has high part, macl has low part
+                operand_type = Type.s32() if signed else Type.u32()
+                product_type = Type.s64() if signed else Type.u64()
+                lhs = as_type(a.reg(1), operand_type, silent=True)
+                rhs = as_type(a.reg(0), operand_type, silent=True)
+                product = BinaryOp(
+                    as_type(lhs, product_type, silent=False),
+                    "*",
+                    as_type(rhs, product_type, silent=False),
+                    type=product_type,
+                )
+                high = BinaryOp(
+                    product,
+                    ">>",
+                    Literal(32),
+                    type=product_type,
+                )
+                s.set_reg(
+                    Register("mach"),
+                    as_type(high, operand_type, silent=True),
+                )
+                s.set_reg(
+                    Register("macl"),
+                    as_type(product, Type.u32(), silent=True),
+                )
+
         elif mnemonic == "clrmac":
             assert not args
             outputs = [Register("macl"), Register("mach")]

--- a/tests/end_to_end/sh-dmul/orig.c
+++ b/tests/end_to_end/sh-dmul/orig.c
@@ -1,0 +1,7 @@
+signed test(signed lhs, signed rhs) {
+    return ((signed long long)lhs * rhs) >> 32;
+}
+
+unsigned test_unsigned(unsigned lhs, unsigned rhs) {
+    return ((unsigned long long)lhs * rhs) >> 32;
+}

--- a/tests/end_to_end/sh-dmul/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-dmul/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --target sh2-gcc-c -f test_unsigned

--- a/tests/end_to_end/sh-dmul/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-dmul/sh2-gcc-o2-out.c
@@ -1,0 +1,7 @@
+s32 test(s32 lhs, s32 rhs) {
+    return (s32) (((s64) lhs * (s64) rhs) >> 0x20);
+}
+
+u32 test_unsigned(u32 lhs, u32 rhs) {
+    return (u32) (((u64) lhs * (u64) rhs) >> 0x20);
+}

--- a/tests/end_to_end/sh-dmul/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-dmul/sh2-gcc-o2-out.c
@@ -1,7 +1,7 @@
 s32 test(s32 lhs, s32 rhs) {
-    return (s32) (((s64) lhs * (s64) rhs) >> 0x20);
+    return (s32) MULT_HI(lhs, rhs);
 }
 
 u32 test_unsigned(u32 lhs, u32 rhs) {
-    return (u32) (((u64) lhs * (u64) rhs) >> 0x20);
+    return MULTU_HI(lhs, rhs);
 }

--- a/tests/end_to_end/sh-dmul/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-dmul/sh2-gcc-o2.s
@@ -1,0 +1,42 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	dmuls.l	r5,r4
+	mov.l	@r15+,r14
+	sts	mach,r3
+	sts	macl,r4
+	sts	mach,r2
+	mov	r3,r1
+	shll	r1
+	subc	r1,r1
+	rts
+	mov	r2,r0
+	.align 2
+	.global	_test_unsigned
+_test_unsigned:
+	mov.l	r14,@-r15
+	mov	r15,r14
+	dmulu.l	r5,r4
+	mov.l	@r15+,r14
+	sts	mach,r3
+	sts	macl,r4
+	mov	r3,r2
+	nop
+	mov	#0,r1
+	rts
+	mov	r2,r0


### PR DESCRIPTION
Supports dmuls.l/dmulu.l. Fixes these cases

```
 s32 test(s32 lhs, s32 rhs) {
-    return (s32) (((s64) lhs * (s64) rhs) >> 0x20);
+    M2C_ERROR(/* unknown instruction: dmuls.l $r5, $r4 */);
+    return M2C_ERROR(/* Read from unset register $mach */);
 }
 
 u32 test_unsigned(u32 lhs, u32 rhs) {
-    return (u32) (((u64) lhs * (u64) rhs) >> 0x20);
+    M2C_ERROR(/* unknown instruction: dmulu.l $r5, $r4 */);
+    return M2C_ERROR(/* Read from unset register $mach */);
 }
 ```
Disclosure: AI assistance was used during development.