### PR TITLE
sh2: implement addc

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -37,6 +37,7 @@ from .translate import (
     Arch,
     ArgLoc,
     BinaryOp,
+    CarryBit,
     Cast,
     ErrorExpr,
     ExprStmt,
@@ -59,6 +60,7 @@ from .evaluate import (
     fold_mul_chains,
     fold_shift_right,
     handle_add,
+    handle_add_real,
     handle_addi,
     handle_bitinv,
     handle_load,
@@ -468,6 +470,22 @@ class Sh2Arch(Arch):
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
                 assert args[1] == Register("pr")
                 assert mem.base == cls.stack_pointer_reg
+
+        elif mnemonic == "addc":
+            assert (
+                len(args) == 2
+                and isinstance(args[0], Register)
+                and isinstance(args[1], Register)
+            )
+            t_reg = Register("condition_bit")
+            inputs = [args[0], args[1], t_reg]
+            outputs = [args[1], t_reg]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                result = handle_add_real(a.reg(1), a.reg(0), a)
+                result = handle_add_real(result, a.regs[t_reg], a)
+                result = s.set_reg(a.reg_ref(1), result)
+                s.set_reg(t_reg, CarryBit(result))
 
         elif mnemonic in cls.instrs_read_modify_write:
             assert len(args) == 2 and isinstance(args[1], Register)

--- a/tests/end_to_end/sh-addc/manual-context.c
+++ b/tests/end_to_end/sh-addc/manual-context.c
@@ -1,0 +1,8 @@
+unsigned test(unsigned lhs, unsigned rhs);
+unsigned test_set(unsigned lhs, unsigned rhs);
+unsigned test_chain(
+    unsigned lhs_low,
+    unsigned lhs_high,
+    unsigned rhs_low,
+    unsigned rhs_high
+);

--- a/tests/end_to_end/sh-addc/manual-flags.txt
+++ b/tests/end_to_end/sh-addc/manual-flags.txt
@@ -1,0 +1,1 @@
+--context manual-context.c --target sh2-gcc-c -f test_set -f test_chain

--- a/tests/end_to_end/sh-addc/manual-out.c
+++ b/tests/end_to_end/sh-addc/manual-out.c
@@ -1,0 +1,11 @@
+u32 test(u32 lhs, u32 rhs) {
+    return lhs + rhs;
+}
+
+u32 test_set(u32 lhs, u32 rhs) {
+    return lhs + rhs + 1;
+}
+
+u32 test_chain(u32 lhs_low, u32 lhs_high, u32 rhs_low, u32 rhs_high) {
+    return lhs_high + rhs_high + M2C_CARRY((lhs_low + rhs_low));
+}

--- a/tests/end_to_end/sh-addc/manual.s
+++ b/tests/end_to_end/sh-addc/manual.s
@@ -1,0 +1,21 @@
+.global _test
+_test:
+    clrt
+    addc r5,r4
+    rts
+    mov r4,r0
+
+.global _test_set
+_test_set:
+    sett
+    addc r5,r4
+    rts
+    mov r4,r0
+
+.global _test_chain
+_test_chain:
+    clrt
+    addc r6,r4
+    addc r7,r5
+    rts
+    mov r5,r0


### PR DESCRIPTION
This implements addc with clear, set, and carry tests.
Disclosure: AI assistance was used during development.