### PR TITLE
sh2: preserve jump table delay slot index move

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -111,6 +111,7 @@ class JumpTablePattern(SimpleAsmPattern):
             return None
         return Replacement(
             [
+                m.body[0],
                 AsmInstruction("tablejmp.fictive", [m.regs["x"], *targets]),
                 AsmInstruction("nop", []),
             ],

--- a/tests/end_to_end/sh-switch-jumptable-delay-slot/orig.c
+++ b/tests/end_to_end/sh-switch-jumptable-delay-slot/orig.c
@@ -1,0 +1,28 @@
+extern int sink(int);
+
+int test(int *values, int result) {
+    int highest = 0;
+    int i;
+
+    for (i = 1; i < 4; i++) {
+        if (values[i] > values[highest]) {
+            highest = i;
+        }
+    }
+
+    switch (highest) {
+    case 0:
+        result *= 2;
+        break;
+    case 1:
+        result += 3;
+        break;
+    case 2:
+        result += sink(result);
+        break;
+    case 3:
+        result -= sink(result);
+        break;
+    }
+    return result;
+}

--- a/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2-out.c
@@ -1,0 +1,35 @@
+s32 _sink(s32, ?, u32, s32);                        /* extern */
+
+s32 test(s32 arg0, s32 arg1) {
+    s32 var_r7;
+    s32 var_r8;
+    u32 var_r3;
+    u32 var_r6;
+
+    var_r8 = arg1;
+    var_r6 = 0;
+    var_r3 = 1;
+    var_r7 = 4;
+    do {
+        if (*(arg0 + var_r7) > *(arg0 + (var_r6 * 4))) {
+            var_r6 = var_r3;
+        }
+        var_r3 += 1;
+        var_r7 += 4;
+    } while ((s32) var_r3 <= 3);
+    switch (var_r6) {
+    case 0:
+        var_r8 *= 2;
+        break;
+    case 1:
+        var_r8 += 3;
+        break;
+    case 2:
+        var_r8 += sink(var_r8, 3, var_r6, var_r7);
+        break;
+    case 3:
+        var_r8 -= sink(var_r8, 3, var_r6, var_r7);
+        break;
+    }
+    return var_r8;
+}

--- a/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-switch-jumptable-delay-slot/sh2-gcc-o2.s
@@ -1,0 +1,84 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r8,@-r15
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov	r5,r8
+	mov	#0,r6
+	mov	#1,r3
+	mov	#3,r5
+	mov	#4,r7
+L5:
+	mov	r6,r1
+	mov	r7,r0
+	mov.l	@(r0,r4),r2
+	shll2	r1
+	mov	r1,r0
+	mov.l	@(r0,r4),r1
+	cmp/gt	r1,r2
+	bf	L4
+	mov	r3,r6
+L4:
+	add	#1,r3
+	cmp/gt	r5,r3
+	bf.s	L5
+	add	#4,r7
+	mov	#3,r1
+	cmp/hi	r1,r6
+	bt.s	L8
+	mov	r6,r1
+	add	r1,r1
+	mova	L13,r0
+	mov.w	@(r0,r1),r1
+	add	r1,r0
+	jmp        @r0
+	nop
+	.align 2
+L13:
+	.word	L9-L13
+	.word	L10-L13
+	.word	L11-L13
+	.word	L12-L13
+L9:
+	bra	L8
+	add	r8,r8
+L10:
+	bra	L8
+	add	#3,r8
+L11:
+	mov.l	L15,r0
+	jsr	@r0
+	mov	r8,r4
+	bra	L8
+	add	r0,r8
+L12:
+	mov.l	L15,r0
+	jsr	@r0
+	mov	r8,r4
+	sub	r0,r8
+L8:
+	mov	r14,r15
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	mov	r8,r0
+	rts
+	mov.l	@r15+,r8
+L16:
+	.align 2
+L15:
+	.long	_sink


### PR DESCRIPTION
This prevents a crash found in the sotn corpus:
```
+Two delay slot instructions in a row is not supported:
+bt.s L8
+tablejmp.fictive $r6, L9, L10, L11, L12
+*/
```
Disclosure: AI assistance was used during development.