### PR TITLE
sh2: handle doubled long-branch jump tables

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -51,6 +51,7 @@ from .translate import (
     as_type,
     as_u16,
     as_u32,
+    early_unwrap,
 )
 
 from .evaluate import (
@@ -76,8 +77,8 @@ from .evaluate import (
 from .types import FunctionSignature, Type
 
 
-def jump_table_targets(m: AsmMatch, mova_index: int) -> Optional[List[AsmGlobalSymbol]]:
-    mova = m.body[mova_index]
+def jump_table_targets(m: AsmMatch) -> Optional[List[AsmGlobalSymbol]]:
+    mova = m.body[0]
     assert isinstance(mova, Instruction)
     assert isinstance(mova.args[0], AsmGlobalSymbol)
 
@@ -101,8 +102,6 @@ def jump_table_targets(m: AsmMatch, mova_index: int) -> Optional[List[AsmGlobalS
 
 class JumpTablePattern(SimpleAsmPattern):
     pattern = make_pattern(
-        "mov $x, $i",
-        "add $i, $i",
         "mova _, $b",
         "mov.w @($b,$i),$i",
         "add $i, $b",
@@ -111,36 +110,11 @@ class JumpTablePattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        targets = jump_table_targets(m, 2)
+        targets = jump_table_targets(m)
         if targets is None:
             return None
         return Replacement(
             [
-                m.body[0],
-                AsmInstruction("tablejmp.fictive", [m.regs["x"], *targets]),
-                AsmInstruction("nop", []),
-            ],
-            len(m.body),
-        )
-
-
-class DoubledJumpTablePattern(SimpleAsmPattern):
-    pattern = make_pattern(
-        "add $i, $i",
-        "mova _, $b",
-        "mov.w @($b,$i),$i",
-        "add $i, $b",
-        "jmp @$b",
-        "nop",
-    )
-
-    def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        targets = jump_table_targets(m, 1)
-        if targets is None:
-            return None
-        return Replacement(
-            [
-                m.body[0],
                 AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets]),
                 AsmInstruction("nop", []),
             ],
@@ -705,7 +679,7 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 Register("r0"), op(a.reg(0), "/", a.reg(1))
             )
-        elif mnemonic in ("tablejmp.fictive", "tablejmp.doubled.fictive"):
+        elif mnemonic == "tablejmp.doubled.fictive":
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []
             for arg in args[1:]:
@@ -715,12 +689,20 @@ class Sh2Arch(Arch):
             jump_target = targets
             is_conditional = True
             has_delay_slot = True
-            if mnemonic == "tablejmp.doubled.fictive":
-                eval_fn = lambda s, a: s.set_switch_expr(
-                    BinaryOp.uint(a.reg(0), ">>", Literal(1)), just_index=True
-                )
-            else:
-                eval_fn = lambda s, a: s.set_switch_expr(a.reg(0), just_index=True)
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                index = a.reg(0)
+                unwrapped = early_unwrap(index)
+                if (
+                    isinstance(unwrapped, BinaryOp)
+                    and unwrapped.op == "*"
+                    and early_unwrap(unwrapped.right) == Literal(2)
+                ):
+                    index = unwrapped.left
+                else:
+                    index = BinaryOp.uint(index, ">>", Literal(1))
+                s.set_switch_expr(index, just_index=True)
+
         elif mnemonic == "movt":
             assert len(args) == 1 and isinstance(args[0], Register)
             inputs = [Register("condition_bit")]
@@ -873,7 +855,6 @@ class Sh2Arch(Arch):
     asm_patterns = [
         DivisionHelperPattern(),
         JumpTablePattern(),
-        DoubledJumpTablePattern(),
         Sh2AddrModeWritebackPattern(),
         NegateTPattern(),
         SubcSelfPattern(),

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -77,29 +77,6 @@ from .evaluate import (
 from .types import FunctionSignature, Type
 
 
-def jump_table_targets(m: AsmMatch) -> Optional[List[AsmGlobalSymbol]]:
-    mova = m.body[0]
-    assert isinstance(mova, Instruction)
-    assert isinstance(mova.args[0], AsmGlobalSymbol)
-
-    table_name = mova.args[0].symbol_name
-    table = m.asm_data.values.get(table_name)
-    if table is None:
-        return None
-    targets: List[AsmGlobalSymbol] = []
-    for entry in table.data:
-        if (
-            not isinstance(entry, AsmSymbolicData)
-            or not isinstance(entry.data, BinOp)
-            or entry.data.op != "-"
-            or not isinstance(entry.data.lhs, AsmGlobalSymbol)
-            or entry.data.rhs != AsmGlobalSymbol(table_name)
-        ):
-            return None
-        targets.append(entry.data.lhs)
-    return targets or None
-
-
 class JumpTablePattern(SimpleAsmPattern):
     pattern = make_pattern(
         "mova _, $b",
@@ -110,8 +87,26 @@ class JumpTablePattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        targets = jump_table_targets(m)
-        if targets is None:
+        mova = m.body[0]
+        assert isinstance(mova, Instruction)
+        assert isinstance(mova.args[0], AsmGlobalSymbol)
+
+        table_name = mova.args[0].symbol_name
+        table = m.asm_data.values.get(table_name)
+        if table is None:
+            return None
+        targets: List[AsmGlobalSymbol] = []
+        for entry in table.data:
+            if (
+                not isinstance(entry, AsmSymbolicData)
+                or not isinstance(entry.data, BinOp)
+                or entry.data.op != "-"
+                or not isinstance(entry.data.lhs, AsmGlobalSymbol)
+                or entry.data.rhs != AsmGlobalSymbol(table_name)
+            ):
+                return None
+            targets.append(entry.data.lhs)
+        if not targets:
             return None
         return Replacement(
             [

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -76,6 +76,29 @@ from .evaluate import (
 from .types import FunctionSignature, Type
 
 
+def jump_table_targets(m: AsmMatch, mova_index: int) -> Optional[List[AsmGlobalSymbol]]:
+    mova = m.body[mova_index]
+    assert isinstance(mova, Instruction)
+    assert isinstance(mova.args[0], AsmGlobalSymbol)
+
+    table_name = mova.args[0].symbol_name
+    table = m.asm_data.values.get(table_name)
+    if table is None:
+        return None
+    targets: List[AsmGlobalSymbol] = []
+    for entry in table.data:
+        if (
+            not isinstance(entry, AsmSymbolicData)
+            or not isinstance(entry.data, BinOp)
+            or entry.data.op != "-"
+            or not isinstance(entry.data.lhs, AsmGlobalSymbol)
+            or entry.data.rhs != AsmGlobalSymbol(table_name)
+        ):
+            return None
+        targets.append(entry.data.lhs)
+    return targets or None
+
+
 class JumpTablePattern(SimpleAsmPattern):
     pattern = make_pattern(
         "mov $x, $i",
@@ -88,31 +111,37 @@ class JumpTablePattern(SimpleAsmPattern):
     )
 
     def replace(self, m: AsmMatch) -> Optional[Replacement]:
-        mova = m.body[2]
-        assert isinstance(mova, Instruction)
-        assert isinstance(mova.args[0], AsmGlobalSymbol)
-
-        table_name = mova.args[0].symbol_name
-        table = m.asm_data.values.get(table_name)
-        if table is None:
-            return None
-        targets: List[AsmGlobalSymbol] = []
-        for entry in table.data:
-            if (
-                not isinstance(entry, AsmSymbolicData)
-                or not isinstance(entry.data, BinOp)
-                or entry.data.op != "-"
-                or not isinstance(entry.data.lhs, AsmGlobalSymbol)
-                or entry.data.rhs != AsmGlobalSymbol(table_name)
-            ):
-                return None
-            targets.append(entry.data.lhs)
-        if not targets:
+        targets = jump_table_targets(m, 2)
+        if targets is None:
             return None
         return Replacement(
             [
                 m.body[0],
                 AsmInstruction("tablejmp.fictive", [m.regs["x"], *targets]),
+                AsmInstruction("nop", []),
+            ],
+            len(m.body),
+        )
+
+
+class DoubledJumpTablePattern(SimpleAsmPattern):
+    pattern = make_pattern(
+        "add $i, $i",
+        "mova _, $b",
+        "mov.w @($b,$i),$i",
+        "add $i, $b",
+        "jmp @$b",
+        "nop",
+    )
+
+    def replace(self, m: AsmMatch) -> Optional[Replacement]:
+        targets = jump_table_targets(m, 1)
+        if targets is None:
+            return None
+        return Replacement(
+            [
+                m.body[0],
+                AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets]),
                 AsmInstruction("nop", []),
             ],
             len(m.body),
@@ -676,7 +705,7 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 Register("r0"), op(a.reg(0), "/", a.reg(1))
             )
-        elif mnemonic == "tablejmp.fictive":
+        elif mnemonic in ("tablejmp.fictive", "tablejmp.doubled.fictive"):
             assert len(args) >= 2 and isinstance(args[0], Register)
             targets = []
             for arg in args[1:]:
@@ -686,7 +715,12 @@ class Sh2Arch(Arch):
             jump_target = targets
             is_conditional = True
             has_delay_slot = True
-            eval_fn = lambda s, a: s.set_switch_expr(a.reg(0), just_index=True)
+            if mnemonic == "tablejmp.doubled.fictive":
+                eval_fn = lambda s, a: s.set_switch_expr(
+                    BinaryOp.uint(a.reg(0), ">>", Literal(1)), just_index=True
+                )
+            else:
+                eval_fn = lambda s, a: s.set_switch_expr(a.reg(0), just_index=True)
         elif mnemonic == "movt":
             assert len(args) == 1 and isinstance(args[0], Register)
             inputs = [Register("condition_bit")]
@@ -839,6 +873,7 @@ class Sh2Arch(Arch):
     asm_patterns = [
         DivisionHelperPattern(),
         JumpTablePattern(),
+        DoubledJumpTablePattern(),
         Sh2AddrModeWritebackPattern(),
         NegateTPattern(),
         SubcSelfPattern(),

--- a/m2c/asm_file.py
+++ b/m2c/asm_file.py
@@ -500,7 +500,7 @@ def parse_file(f: typing.TextIO, arch: ArchAsm, options: Options) -> AsmFile:
     re_whitespace_or_string = re.compile(r'\s+|"(?:\\.|[^\\"])*"')
     re_local_glabel = re.compile("L(_.*_)?[0-9A-F]{7,8}")
     re_local_label = re.compile(
-        "loc_|locret_|def_|lbl_|LAB_|switchD_|jump_|L[0-9]+$|_[0-9A-Fa-f]{7,8}(?:_.*)?$"
+        "loc_|locret_|def_|lbl_|LAB_|switchD_|jump_|LF?[0-9]+$|_[0-9A-Fa-f]{7,8}(?:_.*)?$"
     )
     re_label = re.compile(r'(?:([a-zA-Z0-9_.$]+)|"([a-zA-Z0-9_.$<>@,-]+)"):')
 

--- a/tests/end_to_end/sh-switch-jumptable-long-branch/orig.c
+++ b/tests/end_to_end/sh-switch-jumptable-long-branch/orig.c
@@ -1,0 +1,52 @@
+extern int sink(int);
+
+int test(int value) {
+    value = sink(value) & 0x7F;
+    switch (value) {
+    case 0: return 11;
+    case 1: return 48;
+    case 2: return 85;
+    case 3: return 122;
+    case 4: return 32;
+    case 5: return 69;
+    case 6: return 106;
+    case 7: return 16;
+    case 8: return 53;
+    case 9: return 90;
+    case 10: return 0;
+    case 11: return 37;
+    case 12: return 74;
+    case 13: return 111;
+    case 14: return 21;
+    case 15: return 58;
+    case 16: return 95;
+    case 17: return 5;
+    case 18: return 42;
+    case 19: return 79;
+    case 20: return 116;
+    case 21: return 26;
+    case 22: return 63;
+    case 23: return 100;
+    case 24: return 10;
+    case 25: return 47;
+    case 26: return 84;
+    case 27: return 121;
+    case 28: return 31;
+    case 29: return 68;
+    case 30: return 105;
+    case 31: return 15;
+    case 32: return 52;
+    case 33: return 89;
+    case 34: return 126;
+    case 35: return 36;
+    case 36: return 73;
+    case 37: return 110;
+    case 38: return 20;
+    case 39: return 57;
+    case 40: return 94;
+    case 41: return 4;
+    case 42: return 41;
+    case 43: return 78;
+    default: return sink(value + 1);
+    }
+}

--- a/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-flags.txt
+++ b/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-out.c
@@ -1,0 +1,100 @@
+s32 _sink(s32);                                     /* extern */
+
+s32 test(s32 arg0) {
+    u32 temp_r0;
+
+    temp_r0 = sink() & 0x7F;
+    if (temp_r0 > 0x2BU) {
+        return sink(temp_r0 + 1);
+    }
+    switch ((u32) (temp_r0 * 2) >> 1U) {
+    case 0:
+        return 0xB;
+    case 1:
+        return 0x30;
+    case 2:
+        return 0x55;
+    case 3:
+        return 0x7A;
+    case 4:
+        return 0x20;
+    case 5:
+        return 0x45;
+    case 6:
+        return 0x6A;
+    case 7:
+        return 0x10;
+    case 8:
+        return 0x35;
+    case 9:
+        return 0x5A;
+    case 10:
+        return 0;
+    case 11:
+        return 0x25;
+    case 12:
+        return 0x4A;
+    case 13:
+        return 0x6F;
+    case 14:
+        return 0x15;
+    case 15:
+        return 0x3A;
+    case 16:
+        return 0x5F;
+    case 17:
+        return 5;
+    case 18:
+        return 0x2A;
+    case 19:
+        return 0x4F;
+    case 20:
+        return 0x74;
+    case 21:
+        return 0x1A;
+    case 22:
+        return 0x3F;
+    case 23:
+        return 0x64;
+    case 24:
+        return 0xA;
+    case 25:
+        return 0x2F;
+    case 26:
+        return 0x54;
+    case 27:
+        return 0x79;
+    case 28:
+        return 0x1F;
+    case 29:
+        return 0x44;
+    case 30:
+        return 0x69;
+    case 31:
+        return 0xF;
+    case 32:
+        return 0x34;
+    case 33:
+        return 0x59;
+    case 34:
+        return 0x7E;
+    case 35:
+        return 0x24;
+    case 36:
+        return 0x49;
+    case 37:
+        return 0x6E;
+    case 38:
+        return 0x14;
+    case 39:
+        return 0x39;
+    case 40:
+        return 0x5E;
+    case 41:
+        return 4;
+    case 42:
+        return 0x29;
+    case 43:
+        return 0x4E;
+    }
+}

--- a/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2-out.c
@@ -4,10 +4,7 @@ s32 test(s32 arg0) {
     u32 temp_r0;
 
     temp_r0 = sink() & 0x7F;
-    if (temp_r0 > 0x2BU) {
-        return sink(temp_r0 + 1);
-    }
-    switch ((u32) (temp_r0 * 2) >> 1U) {
+    switch (temp_r0) {                              /* irregular */
     case 0:
         return 0xB;
     case 1:
@@ -96,5 +93,7 @@ s32 test(s32 arg0) {
         return 0x29;
     case 43:
         return 0x4E;
+    default:
+        return sink(temp_r0 + 1);
     }
 }

--- a/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2.s
+++ b/tests/end_to_end/sh-switch-jumptable-long-branch/sh2-gcc-o2.s
@@ -1,0 +1,229 @@
+	.file	"input.i"
+	.data
+
+! Hitachi SH cc1 (cygnus-2.7-96q3 SOA-960904) arguments: -O -fdefer-pop
+! -fcse-follow-jumps -fcse-skip-blocks -fexpensive-optimizations
+! -fthread-jumps -fstrength-reduce -fpeephole -fforce-mem -ffunction-cse
+! -finline -fkeep-static-consts -fcaller-saves -freg-struct-return
+! -fdelayed-branch -frerun-cse-after-loop -fschedule-insns2 -fcommon
+! -fgnu-linker -m2
+
+gcc2_compiled.:
+___gnu_compiled_c:
+	.text
+	.align 2
+	.global	_test
+_test:
+	mov.l	r8,@-r15
+	mov.l	r14,@-r15
+	sts.l	pr,@-r15
+	mov	r15,r14
+	mov.l	L50,r8
+	jsr	@r8
+	mov	r4,r0
+	and	#127,r0
+	mov	#43,r1
+	cmp/hi	r1,r0
+	bf.s	LF100
+	mov	r0,r1
+	bra	L47
+	nop
+LF100:
+	add	r1,r1
+	mova	L48,r0
+	mov.w	@(r0,r1),r1
+	add	r1,r0
+	jmp        @r0
+	nop
+	.align 2
+L48:
+	.word	L3-L48
+	.word	L4-L48
+	.word	L5-L48
+	.word	L6-L48
+	.word	L7-L48
+	.word	L8-L48
+	.word	L9-L48
+	.word	L10-L48
+	.word	L11-L48
+	.word	L12-L48
+	.word	L13-L48
+	.word	L14-L48
+	.word	L15-L48
+	.word	L16-L48
+	.word	L17-L48
+	.word	L18-L48
+	.word	L19-L48
+	.word	L20-L48
+	.word	L21-L48
+	.word	L22-L48
+	.word	L23-L48
+	.word	L24-L48
+	.word	L25-L48
+	.word	L26-L48
+	.word	L27-L48
+	.word	L28-L48
+	.word	L29-L48
+	.word	L30-L48
+	.word	L31-L48
+	.word	L32-L48
+	.word	L33-L48
+	.word	L34-L48
+	.word	L35-L48
+	.word	L36-L48
+	.word	L37-L48
+	.word	L38-L48
+	.word	L39-L48
+	.word	L40-L48
+	.word	L41-L48
+	.word	L42-L48
+	.word	L43-L48
+	.word	L44-L48
+	.word	L45-L48
+	.word	L46-L48
+L3:
+	bra	L49
+	mov	#11,r0
+L4:
+	bra	L49
+	mov	#48,r0
+L5:
+	bra	L49
+	mov	#85,r0
+L6:
+	bra	L49
+	mov	#122,r0
+L7:
+	bra	L49
+	mov	#32,r0
+L8:
+	bra	L49
+	mov	#69,r0
+L9:
+	bra	L49
+	mov	#106,r0
+L10:
+	bra	L49
+	mov	#16,r0
+L11:
+	bra	L49
+	mov	#53,r0
+L12:
+	bra	L49
+	mov	#90,r0
+L13:
+	bra	L49
+	mov	#0,r0
+L14:
+	bra	L49
+	mov	#37,r0
+L15:
+	bra	L49
+	mov	#74,r0
+L16:
+	bra	L49
+	mov	#111,r0
+L17:
+	bra	L49
+	mov	#21,r0
+L18:
+	bra	L49
+	mov	#58,r0
+L19:
+	bra	L49
+	mov	#95,r0
+L20:
+	bra	L49
+	mov	#5,r0
+L21:
+	bra	L49
+	mov	#42,r0
+L22:
+	bra	L49
+	mov	#79,r0
+L23:
+	bra	L49
+	mov	#116,r0
+L24:
+	bra	L49
+	mov	#26,r0
+L25:
+	bra	L49
+	mov	#63,r0
+L26:
+	bra	L49
+	mov	#100,r0
+L27:
+	bra	L49
+	mov	#10,r0
+L28:
+	bra	L49
+	mov	#47,r0
+L29:
+	bra	L49
+	mov	#84,r0
+L30:
+	bra	L49
+	mov	#121,r0
+L31:
+	bra	L49
+	mov	#31,r0
+L32:
+	bra	L49
+	mov	#68,r0
+L33:
+	bra	L49
+	mov	#105,r0
+L34:
+	bra	L49
+	mov	#15,r0
+L35:
+	bra	L49
+	mov	#52,r0
+L36:
+	bra	L49
+	mov	#89,r0
+L37:
+	bra	L49
+	mov	#126,r0
+L38:
+	bra	L49
+	mov	#36,r0
+L39:
+	bra	L49
+	mov	#73,r0
+L40:
+	bra	L49
+	mov	#110,r0
+L41:
+	bra	L49
+	mov	#20,r0
+L42:
+	bra	L49
+	mov	#57,r0
+L43:
+	bra	L49
+	mov	#94,r0
+L44:
+	bra	L49
+	mov	#4,r0
+L45:
+	bra	L49
+	mov	#41,r0
+L46:
+	bra	L49
+	mov	#78,r0
+L47:
+	add	#1,r0
+	jsr	@r8
+	mov	r0,r4
+L49:
+	mov	r14,r15
+	lds.l	@r15+,pr
+	mov.l	@r15+,r14
+	rts
+	mov.l	@r15+,r8
+L51:
+	.align 2
+L50:
+	.long	_sink


### PR DESCRIPTION
This adds another jump table handler for tables where the index is doubled. In isolation we could get rid of "tablejmp.doubled.fictive" by removing the `add r1,r1` but other doubled table types require the doubled index to be available. I'm intending to add these in a follow-up.

Disclosure: AI assistance was used during development.