### PR TITLE
sh2: fix incorrect writeback increments

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -234,7 +234,9 @@ class Sh2AddrModeWritebackPattern(AsmPattern):
         if addr.writeback == Writeback.PRE:
             return Replacement(
                 [
-                    AsmInstruction("add", [AsmLiteral(-stride), addr.base]),
+                    AsmInstruction(
+                        "addbytes.fictive", [AsmLiteral(-stride), addr.base]
+                    ),
                     AsmInstruction(instr.mnemonic, new_args),
                 ],
                 1,
@@ -243,7 +245,7 @@ class Sh2AddrModeWritebackPattern(AsmPattern):
         return Replacement(
             [
                 AsmInstruction(instr.mnemonic, new_args),
-                AsmInstruction("add", [AsmLiteral(stride), addr.base]),
+                AsmInstruction("addbytes.fictive", [AsmLiteral(stride), addr.base]),
             ],
             1,
         )
@@ -386,6 +388,44 @@ class Sh2Arch(Arch):
             inputs = [args[1]]
             outputs = [args[0]]
             eval_fn = lambda s, a: s.set_reg(a.reg_ref(0), a.reg(1))
+        elif mnemonic == "addbytes.fictive":
+            assert (
+                len(args) == 2
+                and isinstance(args[0], AsmLiteral)
+                and isinstance(args[1], Register)
+            )
+            inputs = [args[1]]
+            outputs = [args[1]]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                source = a.reg(1)
+                byte_delta = a.full_imm(0)
+                assert isinstance(byte_delta, Literal)
+                delta = byte_delta.value
+                if source.type.is_pointer_or_array():
+                    target = source.type.get_pointer_target()
+                    if target is not None:
+                        target_size = target.get_size_bytes()
+                        if target_size and delta % target_size == 0:
+                            element_delta = delta // target_size
+                            if element_delta < 0:
+                                expr = BinaryOp(
+                                    left=source,
+                                    op="-",
+                                    right=Literal(-element_delta),
+                                    type=source.type,
+                                )
+                            else:
+                                expr = BinaryOp(
+                                    left=source,
+                                    op="+",
+                                    right=Literal(element_delta),
+                                    type=source.type,
+                                )
+                            s.set_reg(a.reg_ref(1), expr)
+                            return
+                s.set_reg(a.reg_ref(1), handle_add_real(source, byte_delta, a))
+
         elif mnemonic == "mova":
             assert (
                 len(args) == 2

--- a/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-direct-register-memory/sh2-gcc-o2-out.c
@@ -34,7 +34,7 @@ s16 test_loadw_postinc(s16 **ptr) {
     s16 *temp_r1;
 
     temp_r1 = *ptr;
-    *ptr = temp_r1 + 2;
+    *ptr = temp_r1 + 1;
     return *temp_r1;
 }
 
@@ -42,7 +42,7 @@ s32 test_loadl_postinc(s32 **ptr) {
     s32 *temp_r1;
 
     temp_r1 = *ptr;
-    *ptr = temp_r1 + 4;
+    *ptr = temp_r1 + 1;
     return *temp_r1;
 }
 
@@ -57,7 +57,7 @@ void test_storeb_predec(s8 **ptr, s8 value) {
 void test_storew_predec(s16 **ptr, s16 value) {
     s16 *temp_r1;
 
-    temp_r1 = *ptr - 2;
+    temp_r1 = *ptr - 1;
     *temp_r1 = value;
     *ptr = temp_r1;
 }
@@ -65,7 +65,7 @@ void test_storew_predec(s16 **ptr, s16 value) {
 void test_storel_predec(s32 **ptr, s32 value) {
     s32 *temp_r1;
 
-    temp_r1 = *ptr - 4;
+    temp_r1 = *ptr - 1;
     *temp_r1 = value;
     *ptr = temp_r1;
 }

--- a/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-out.c
+++ b/tests/end_to_end/sh-writeback-non-r15/sh2-gcc-o2-out.c
@@ -2,14 +2,14 @@ s32 test(s32 **ptr) {
     s32 *temp_r1;
 
     temp_r1 = *ptr;
-    *ptr = temp_r1 + 4;
+    *ptr = temp_r1 + 1;
     return *temp_r1;
 }
 
 void test_storel_predec(s32 **ptr, s32 value) {
     s32 *temp_r1;
 
-    temp_r1 = *ptr - 4;
+    temp_r1 = *ptr - 1;
     *temp_r1 = value;
     *ptr = temp_r1;
 }
@@ -25,7 +25,7 @@ s8 test_loadb_predec(s8 **ptr) {
 s16 test_loadw_predec(s16 **ptr) {
     s16 *temp_r1;
 
-    temp_r1 = *ptr - 2;
+    temp_r1 = *ptr - 1;
     *ptr = temp_r1;
     return *temp_r1;
 }


### PR DESCRIPTION
Previously the writeback instructions were incrementing pointers by the wrong amount. This adds a `addbytes.fictive` instruction to keep this change separate from the stack handling. Now we get:
```
s16 *temp_r1;
temp_r1 = *ptr - 1;
```
instead of
```
temp_r1 = *ptr - 2;
```
Disclosure: AI assistance was used in developing this PR.