### PR TITLE
sh2: implement xtrct

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -893,6 +893,11 @@ class Sh2Arch(Arch):
         "and": lambda a: BinaryOp.int(a.reg(1), "&", a.reg_or_imm(0)),
         "or": lambda a: handle_or(a.reg(1), a.reg_or_imm(0)),
         "xor": lambda a: handle_xor(a.reg(1), a.reg_or_imm(0)),
+        "xtrct": lambda a: BinaryOp.uint(
+            BinaryOp.ushift(a.reg(1), ">>", Literal(16)),
+            "|",
+            BinaryOp.int(a.reg(0), "<<", Literal(16)),
+        ),
     }
 
     instrs_source_dest: InstrMap = {

--- a/tests/end_to_end/sh-xtrct/manual-flags.txt
+++ b/tests/end_to_end/sh-xtrct/manual-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-xtrct/manual-out.c
+++ b/tests/end_to_end/sh-xtrct/manual-out.c
@@ -1,0 +1,3 @@
+u32 test(u32 lhs, u32 rhs) {
+    return (u32) (lhs >> 0x10) | (u32) (rhs << 0x10);
+}

--- a/tests/end_to_end/sh-xtrct/manual.s
+++ b/tests/end_to_end/sh-xtrct/manual.s
@@ -1,0 +1,6 @@
+.text
+.globl test
+test:
+    xtrct r5,r4
+    rts
+    mov r4,r0

--- a/tests/end_to_end/sh-xtrct/orig.c
+++ b/tests/end_to_end/sh-xtrct/orig.c
@@ -1,0 +1,3 @@
+unsigned test(unsigned lhs, unsigned rhs) {
+    return (lhs >> 16) | (rhs << 16);
+}


### PR DESCRIPTION
Implements the xtrct instruction.
Disclosure: AI assistance was used in developing this PR.