### PR TITLE
sh2: implement swap.b

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -912,6 +912,23 @@ class Sh2Arch(Arch):
             "|",
             BinaryOp.ushift(a.reg(0), ">>", Literal(16)),
         ),
+        "swap.b": lambda a: BinaryOp.uint(
+            BinaryOp.uint(
+                BinaryOp.int(a.reg(0), "&", Literal(0xFFFF0000)),
+                "|",
+                BinaryOp.int(
+                    BinaryOp.int(a.reg(0), "&", Literal(0xFF)),
+                    "<<",
+                    Literal(8),
+                ),
+            ),
+            "|",
+            BinaryOp.int(
+                BinaryOp.ushift(a.reg(0), ">>", Literal(8)),
+                "&",
+                Literal(0xFF),
+            ),
+        ),
         "shar16.fictive": lambda a: fold_shift_right(a.reg(0), 16, signed=True),
     }
 

--- a/tests/end_to_end/sh-swapb/manual-flags.txt
+++ b/tests/end_to_end/sh-swapb/manual-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-swapb/manual-out.c
+++ b/tests/end_to_end/sh-swapb/manual-out.c
@@ -1,0 +1,3 @@
+u32 test(u32 value) {
+    return (u32) ((u32) (value & 0xFFFF0000) | (u32) ((value & 0xFF) << 8)) | (u32) ((value >> 8) & 0xFF);
+}

--- a/tests/end_to_end/sh-swapb/manual.s
+++ b/tests/end_to_end/sh-swapb/manual.s
@@ -1,0 +1,5 @@
+.text
+.globl test
+test:
+    rts
+    swap.b r4,r0

--- a/tests/end_to_end/sh-swapb/orig.c
+++ b/tests/end_to_end/sh-swapb/orig.c
@@ -1,0 +1,3 @@
+unsigned test(unsigned value) {
+    return (value & 0xFFFF0000U) | ((value & 0xFFU) << 8) | ((value >> 8) & 0xFFU);
+}


### PR DESCRIPTION
Implements the swap.b instruction.
Disclosure: AI assistance was used in developing this PR.