### PR TITLE
sh2: add cmp/str intrinsic

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -872,6 +872,7 @@ class Sh2Arch(Arch):
         "cmp/gt": lambda a: BinaryOp.scmp(a.reg(1), ">", a.reg(0)),
         "cmp/hi": lambda a: BinaryOp.ucmp(a.reg(1), ">", a.reg(0)),
         "cmp/hs": lambda a: BinaryOp.ucmp(a.reg(1), ">=", a.reg(0)),
+        "cmp/str": lambda a: fn_op("M2C_CMP_STR", [a.reg(1), a.reg(0)], Type.boolean()),
         "tst": lambda a: (
             BinaryOp.icmp(a.reg(1), "==", Literal(0))
             if a.reg_ref(1) == a.raw_arg(0)

--- a/m2c_macros.h
+++ b/m2c_macros.h
@@ -63,4 +63,6 @@ typedef s64 M2C_UNK64;
 #define M2C_STORE_GBR(a)
 #define M2C_STORE_VBR(a)
 
+#define M2C_CMP_STR(a, b) (0)
+
 #endif

--- a/tests/end_to_end/sh-cmpstr/manual-flags.txt
+++ b/tests/end_to_end/sh-cmpstr/manual-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-cmpstr/manual-out.c
+++ b/tests/end_to_end/sh-cmpstr/manual-out.c
@@ -1,0 +1,3 @@
+s32 test(s32 arg0, s32 arg1) {
+    return M2C_CMP_STR(arg0, arg1);
+}

--- a/tests/end_to_end/sh-cmpstr/manual.s
+++ b/tests/end_to_end/sh-cmpstr/manual.s
@@ -1,0 +1,7 @@
+.text
+.globl test
+test:
+    cmp/str r5,r4
+    movt r0
+    rts
+    nop


### PR DESCRIPTION
`cmp/str` checks if any of the 4 bytes in a register are non-zero and sets T. It seems to be meant to enable faster scanning for the null byte in strings. I added an intrinsic for it since I think this only shows up in handwritten code.
 Disclosure: AI assistance was used in developing this PR.