### PR TITLE
sh2: implement tas.b

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -816,6 +816,22 @@ class Sh2Arch(Arch):
                 condition = condition_from_expr(a.regs[Register("condition_bit")])
                 s.set_reg(Register("condition_bit"), condition.negated())
 
+        elif mnemonic == "tas.b":
+            assert (
+                len(args) == 1
+                and isinstance(args[0], AsmAddressMode)
+                and args[0].addend == AsmLiteral(0)
+            )
+            base = args[0].base
+            t_reg = Register("condition_bit")
+            inputs = [base]
+            outputs = [t_reg]
+            is_load = is_store = True
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                result = fn_op("M2C_TAS_B", [a.regs[base]], Type.intish())
+                s.set_reg(t_reg, result)
+
         elif mnemonic == "stc":
             assert (
                 len(args) == 2

--- a/m2c_macros.h
+++ b/m2c_macros.h
@@ -64,5 +64,6 @@ typedef s64 M2C_UNK64;
 #define M2C_STORE_VBR(a)
 
 #define M2C_CMP_STR(a, b) (0)
+#define M2C_TAS_B(a) (0)
 
 #endif

--- a/tests/end_to_end/sh-tasb/manual-flags.txt
+++ b/tests/end_to_end/sh-tasb/manual-flags.txt
@@ -1,0 +1,1 @@
+--context orig.c --target sh2-gcc-c

--- a/tests/end_to_end/sh-tasb/manual-out.c
+++ b/tests/end_to_end/sh-tasb/manual-out.c
@@ -1,0 +1,6 @@
+s32 test(u8 *p) {
+    if (!M2C_TAS_B(p)) {
+        return 0;
+    }
+    return 1;
+}

--- a/tests/end_to_end/sh-tasb/manual.s
+++ b/tests/end_to_end/sh-tasb/manual.s
@@ -1,0 +1,11 @@
+.text
+.globl test
+test:
+    tas.b @r4
+    bt .Lfree
+    mov #0,r0
+    rts
+    nop
+.Lfree:
+    rts
+    mov #1,r0

--- a/tests/end_to_end/sh-tasb/orig.c
+++ b/tests/end_to_end/sh-tasb/orig.c
@@ -1,0 +1,3 @@
+int test(unsigned char *p) {
+    return 0;
+}


### PR DESCRIPTION
This adds an instrinsic for tas.b As far as I know it's only used in handwritten mutex-locking type code.
Disclosure: AI assistance was used in developing this PR.