### PR TITLE
sh2: add shc braf jump table support

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -164,6 +164,48 @@ class JumpTablePattern(AsmPattern):
         return None
 
 
+class BrafJumpTablePattern(SimpleAsmPattern):
+    pattern = make_pattern(
+        "mova _, $b",
+        "mov.w @($b,$i),$b",
+        "braf $b",
+        "nop",
+        ".base:",
+    )
+
+    def replace(self, m: AsmMatch) -> Optional[Replacement]:
+        mova = m.body[0]
+        assert isinstance(mova, Instruction)
+        if not isinstance(mova.args[0], AsmGlobalSymbol):
+            return None
+        table = m.asm_data.values.get(mova.args[0].symbol_name)
+        if table is None:
+            return None
+        base = m.labels[".base"]
+        targets: List[AsmGlobalSymbol] = []
+        for entry in table.data:
+            if (
+                not isinstance(entry, AsmSymbolicData)
+                or not isinstance(entry.data, BinOp)
+                or entry.data.op != "-"
+                or not isinstance(entry.data.lhs, AsmGlobalSymbol)
+                or not isinstance(entry.data.rhs, AsmGlobalSymbol)
+                or entry.data.rhs.symbol_name not in base.names
+            ):
+                return None
+            targets.append(entry.data.lhs)
+        if not targets:
+            return None
+        return Replacement(
+            [
+                AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets]),
+                AsmInstruction("nop", []),
+                base,
+            ],
+            len(m.body),
+        )
+
+
 class NegateTPattern(SimpleAsmPattern):
     pattern = make_pattern(
         "rotcl $r",
@@ -999,6 +1041,7 @@ class Sh2Arch(Arch):
     asm_patterns = [
         FarJumpPattern(),
         JumpTablePattern(),
+        BrafJumpTablePattern(),
         Sh2AddrModeWritebackPattern(),
         NegateTPattern(),
         Shar31Pattern(),

--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -154,13 +154,8 @@ class JumpTablePattern(AsmPattern):
                 targets.append(entry.data.lhs)
             if not targets:
                 return None
-            return Replacement(
-                [
-                    AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets]),
-                    AsmInstruction("nop", []),
-                ],
-                len(m.body),
-            )
+            jump = AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets])
+            return Replacement([jump], len(m.body))
         return None
 
 
@@ -196,14 +191,8 @@ class BrafJumpTablePattern(SimpleAsmPattern):
             targets.append(entry.data.lhs)
         if not targets:
             return None
-        return Replacement(
-            [
-                AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets]),
-                AsmInstruction("nop", []),
-                base,
-            ],
-            len(m.body),
-        )
+        jump = AsmInstruction("tablejmp.doubled.fictive", [m.regs["i"], *targets])
+        return Replacement([jump, base], len(m.body))
 
 
 class NegateTPattern(SimpleAsmPattern):
@@ -823,7 +812,6 @@ class Sh2Arch(Arch):
             inputs = [args[0]]
             jump_target = targets
             is_conditional = True
-            has_delay_slot = True
 
             def eval_fn(s: NodeState, a: InstrArgs) -> None:
                 index = a.reg(0)

--- a/tests/end_to_end/sh-braf-switch/manual-flags.txt
+++ b/tests/end_to_end/sh-braf-switch/manual-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c

--- a/tests/end_to_end/sh-braf-switch/manual-out.c
+++ b/tests/end_to_end/sh-braf-switch/manual-out.c
@@ -1,0 +1,12 @@
+s32 test(u32 arg0) {
+    switch (arg0) {
+    case 0:
+        return 0xA;
+    case 1:
+        return 0x14;
+    case 2:
+        return 0x1E;
+    default:
+        return -1;
+    }
+}

--- a/tests/end_to_end/sh-braf-switch/manual.s
+++ b/tests/end_to_end/sh-braf-switch/manual.s
@@ -1,0 +1,30 @@
+.text
+.globl test
+test:
+    mov #3,r1
+    cmp/hs r1,r4
+    bt .Ldefault
+    mov r4,r0
+    shll r0
+    mov r0,r1
+    mova .Ltable,r0
+    mov.w @(r0,r1),r0
+    braf r0
+    nop
+.Lbase:
+.Ltable:
+    .word .Lcase0-.Lbase
+    .word .Lcase1-.Lbase
+    .word .Lcase2-.Lbase
+.Lcase0:
+    rts
+    mov #10,r0
+.Lcase1:
+    rts
+    mov #20,r0
+.Lcase2:
+    rts
+    mov #30,r0
+.Ldefault:
+    rts
+    mov #-1,r0


### PR DESCRIPTION
SHC is the SH2 compiler by Hitachi. This adds support for a type of jump table generated by it that uses `braf`.  Disclosure: AI assistance was used in developing this PR.