### PR TITLE
sh2: support div0u sequences

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -235,6 +235,28 @@ class BsrfCallPattern(SimpleAsmPattern):
         )
 
 
+DIV1_STEP_COUNT = 32
+
+
+class Div0u32Pattern(SimpleAsmPattern):
+
+    pattern = make_pattern(
+        "xor $r, $r",
+        "div0u",
+        *["rotcl $q", "div1 $d,$r"] * DIV1_STEP_COUNT,
+        "rotcl $q",
+    )
+
+    def replace(self, m: AsmMatch) -> Optional[Replacement]:
+        quotient, divisor, rem = m.regs["q"], m.regs["d"], m.regs["r"]
+        if len({quotient, divisor, rem}) != 3:
+            return None
+        return Replacement(
+            [AsmInstruction("udivmod32.fictive", [quotient, divisor, quotient, rem])],
+            len(m.body),
+        )
+
+
 class NegateTPattern(SimpleAsmPattern):
     pattern = make_pattern(
         "rotcl $r",
@@ -683,6 +705,19 @@ class Sh2Arch(Arch):
             eval_fn = lambda s, a: s.set_reg(
                 a.reg_ref(1), cls.instrs_source_dest[mnemonic](a)
             )
+        elif mnemonic == "udivmod32.fictive":
+            div_args: List[Location] = [
+                arg for arg in args if isinstance(arg, Register)
+            ]
+            assert len(div_args) == 4
+            inputs = div_args[:2]
+            outputs = div_args[2:]
+
+            def eval_fn(s: NodeState, a: InstrArgs) -> None:
+                dividend, divisor = a.reg(0), a.reg(1)
+                s.set_reg(a.reg_ref(2), BinaryOp.uint(dividend, "/", divisor))
+                s.set_reg(a.reg_ref(3), BinaryOp.uint(dividend, "%", divisor))
+
         elif mnemonic in cls.instrs_intrinsics:
             assert isinstance(args[0], Register)
             inputs = [arg for arg in args[1:] if isinstance(arg, Register)]
@@ -1079,6 +1114,7 @@ class Sh2Arch(Arch):
         JumpTablePattern(),
         BrafJumpTablePattern(),
         BsrfCallPattern(),
+        Div0u32Pattern(),
         Sh2AddrModeWritebackPattern(),
         NegateTPattern(),
         Shar31Pattern(),

--- a/tests/end_to_end/sh-div0u32/manual-flags.txt
+++ b/tests/end_to_end/sh-div0u32/manual-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c --context orig.c

--- a/tests/end_to_end/sh-div0u32/manual-out.c
+++ b/tests/end_to_end/sh-div0u32/manual-out.c
@@ -1,0 +1,3 @@
+u32 test(u32 dividend, u32 divisor) {
+    return dividend / divisor;
+}

--- a/tests/end_to_end/sh-div0u32/manual.s
+++ b/tests/end_to_end/sh-div0u32/manual.s
@@ -1,0 +1,73 @@
+.text
+.globl test
+test:
+    mov r4,r0
+    xor r1,r1
+    div0u
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    rts
+    nop

--- a/tests/end_to_end/sh-div0u32/orig.c
+++ b/tests/end_to_end/sh-div0u32/orig.c
@@ -1,0 +1,4 @@
+typedef unsigned int u32;
+u32 test(u32 dividend, u32 divisor) {
+    return dividend / divisor;
+}

--- a/tests/end_to_end/sh-rem0u32/manual-flags.txt
+++ b/tests/end_to_end/sh-rem0u32/manual-flags.txt
@@ -1,0 +1,1 @@
+--target sh2-gcc-c --context orig.c

--- a/tests/end_to_end/sh-rem0u32/manual-out.c
+++ b/tests/end_to_end/sh-rem0u32/manual-out.c
@@ -1,0 +1,3 @@
+u32 test(u32 dividend, u32 divisor) {
+    return dividend % divisor;
+}

--- a/tests/end_to_end/sh-rem0u32/manual.s
+++ b/tests/end_to_end/sh-rem0u32/manual.s
@@ -1,0 +1,74 @@
+.text
+.globl test
+test:
+    mov r4,r0
+    xor r1,r1
+    div0u
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    div1 r5,r1
+    rotcl r0
+    mov r1,r0
+    rts
+    nop

--- a/tests/end_to_end/sh-rem0u32/orig.c
+++ b/tests/end_to_end/sh-rem0u32/orig.c
@@ -1,0 +1,3 @@
+u32 test(u32 dividend, u32 divisor) {
+    return dividend % divisor;
+}


### PR DESCRIPTION
SHC inlines these sorts of division sequences:
```
div0u
rotcl r0
div1 r5,r1
etc ...
```
This adds a fictive instruction to handle unsigned division and modulo. Disclosure: AI assistance