### PR TITLE
sh4: add target, test infra and shc to gas converter

### DIFF
--- a/m2c/arch_sh.py
+++ b/m2c/arch_sh.py
@@ -329,7 +329,7 @@ class Shar16Pattern(IrPattern):
 
 
 class Sh2Arch(Arch):
-    arch = Target.ArchEnum.SH2
+    arch = Target.ArchEnum.SH
 
     def c_symbol_name(self, asm_name: str) -> str:
         if (
@@ -1291,3 +1291,7 @@ class Sh2Arch(Arch):
                 Cast(expr, reinterpret=True, silent=False, type=Type.u64())
             ),
         }
+
+
+class Sh4Arch(Sh2Arch):
+    pass

--- a/m2c/evaluate.py
+++ b/m2c/evaluate.py
@@ -489,7 +489,7 @@ def handle_load(args: InstrArgs, type: Type) -> Expression:
 
         arch = args.stack_info.global_info.arch.arch
         is_arm = arch == Target.ArchEnum.ARM
-        is_sh = arch == Target.ArchEnum.SH2
+        is_sh = arch == Target.ArchEnum.SH
         if is_arm and isinstance(args.raw_arg(1), AsmAddressMode):
             # For ARM, only allow constants loaded through `ldr pool`.
             # Do allow non-zero offsets: they occur in raw agbcc output which

--- a/m2c/flow_graph.py
+++ b/m2c/flow_graph.py
@@ -327,7 +327,7 @@ def normalize_ido_likely_branches(
         if not item.is_branch_likely and next_mn == "nop":
             return False
 
-        if arch.arch == Target.ArchEnum.SH2:
+        if arch.arch == Target.ArchEnum.SH:
             assert isinstance(item.jump_target, JumpTarget)
             label = item.jump_target.target
             if not (next_mn.startswith("cmp/") or next_mn == "tst"):
@@ -354,7 +354,7 @@ def normalize_ido_likely_branches(
                 return False
         return True
 
-    if arch.arch == Target.ArchEnum.SH2:
+    if arch.arch == Target.ArchEnum.SH:
         for label in asm_data.mentioned_labels:
             untouched_targets |= label_names.get(label, set())
         for item, next_item in zip(function.body, function.body[1:]):

--- a/m2c/main.py
+++ b/m2c/main.py
@@ -26,7 +26,7 @@ from .types import TypePool
 from .arch_arm import ArmArch, ArmGbaArch
 from .arch_mips import MipsArch, MipseeArch
 from .arch_ppc import PpcArch
-from .arch_sh import Sh2Arch
+from .arch_sh import Sh2Arch, Sh4Arch
 
 
 @dataclass
@@ -100,8 +100,11 @@ def run(options: Options) -> int:
             arch = ArmGbaArch()
         else:
             arch = ArmArch()
-    elif options.target.arch == Target.ArchEnum.SH2:
-        arch = Sh2Arch()
+    elif options.target.arch == Target.ArchEnum.SH:
+        if options.target.platform == Target.PlatformEnum.SH4:
+            arch = Sh4Arch()
+        else:
+            arch = Sh2Arch()
     else:
         raise ValueError(f"Invalid target arch: {options.target.arch}")
 

--- a/m2c/options.py
+++ b/m2c/options.py
@@ -43,6 +43,7 @@ class Target:
         ARM = "arm"
         GBA = "gba"
         SH2 = "sh2"
+        SH4 = "sh4"
 
         @property
         def arch(self) -> Target.ArchEnum:
@@ -58,8 +59,8 @@ class Target:
                 return Target.ArchEnum.ARM
             elif self == Target.PlatformEnum.GBA:
                 return Target.ArchEnum.ARM
-            elif self == Target.PlatformEnum.SH2:
-                return Target.ArchEnum.SH2
+            elif self in (Target.PlatformEnum.SH2, Target.PlatformEnum.SH4):
+                return Target.ArchEnum.SH
             else:
                 assert_never(self)
 
@@ -67,7 +68,7 @@ class Target:
         MIPS = "mips"
         PPC = "ppc"
         ARM = "arm"
-        SH2 = "sh2"
+        SH = "sh"
 
     class EndianEnum(ChoicesEnum):
         LITTLE = "little"
@@ -77,6 +78,7 @@ class Target:
         IDO = "ido"
         GCC = "gcc"
         MWCC = "mwcc"
+        SHC = "shc"
 
     class LanguageEnum(ChoicesEnum):
         C = "c"
@@ -108,12 +110,15 @@ class Target:
                 Target.PlatformEnum.MIPSEE,
                 Target.PlatformEnum.ARM,
                 Target.PlatformEnum.GBA,
+                Target.PlatformEnum.SH4,
             ):
                 endian = Target.EndianEnum.LITTLE
             arch = platform.arch
 
             if len(terms) >= 2:
                 compiler = Target.CompilerEnum(terms[1])
+            elif platform == Target.PlatformEnum.SH4:
+                compiler = Target.CompilerEnum.SHC
             elif arch == Target.ArchEnum.PPC:
                 compiler = Target.CompilerEnum.MWCC
             elif arch == Target.ArchEnum.MIPS and endian == Target.EndianEnum.BIG:

--- a/m2c/translate.py
+++ b/m2c/translate.py
@@ -672,21 +672,21 @@ def get_stack_info(
             # pointers enabled; thus fp should be treated the same as sp.
             info.frame_pointer_reg = inst.args[0]
         elif (
-            arch_mnemonic == "sh2:mov"
+            arch_mnemonic == "sh:mov"
             and inst.args[0] == arch.stack_pointer_reg
             and isinstance(inst.args[1], Register)
             and inst.args[1] in arch.frame_pointer_regs
         ):
             info.frame_pointer_reg = inst.args[1]
         elif (
-            arch_mnemonic == "sh2:add"
+            arch_mnemonic == "sh:add"
             and isinstance(inst.args[0], AsmLiteral)
             and inst.args[0].as_s8() < 0
             and inst.args[1] == arch.stack_pointer_reg
         ):
             info.allocated_stack_size += -inst.args[0].as_s8()
         elif (
-            arch_mnemonic in ("sh2:mov.l", "sh2:sts.l")
+            arch_mnemonic in ("sh:mov.l", "sh:sts.l")
             and isinstance(inst.args[0], Register)
             and inst.args[0] in arch.saved_regs
             and isinstance(inst.args[1], AsmAddressMode)
@@ -757,7 +757,7 @@ def get_stack_info(
             assert isinstance(inst.args[2], AsmLiteral)
             temp_reg_values[inst.args[0]] |= inst.args[2].value
 
-    if arch.arch in (Target.ArchEnum.ARM, Target.ArchEnum.SH2):
+    if arch.arch in (Target.ArchEnum.ARM, Target.ArchEnum.SH):
         # On ARM and SH we don't know the stack size up front, so
         # callee_saved_offsets needs to be adjusted after scanning the full first block.
         for i in range(len(callee_saved_offsets)):

--- a/tests/add_test.py
+++ b/tests/add_test.py
@@ -11,6 +11,8 @@ from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass, field, replace
 
+import shc_to_gas
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,6 +29,7 @@ class PathsToBinaries:
     MWCC_CC: Optional[Path]
     AGBCC: Optional[Path]
     SH_CC: Optional[Path]
+    SHC_CC: Optional[Path]
     WINE: Optional[Path]
 
 
@@ -54,6 +57,10 @@ def get_environment_variables() -> PathsToBinaries:
         "SH_CC",
         "env variable SH_CC should point to SHGCC. see tools/setup_sh_compiler.sh",
     )
+    SHC_CC = load(
+        "SHC_CC",
+        "env variable SHC_CC should point to SHC",
+    )
     WINE = None
     if MWCC_CC and sys.platform.startswith("linux"):
         WINE = load("WINE", "env variable WINE should point to wine or wibo binary")
@@ -62,6 +69,7 @@ def get_environment_variables() -> PathsToBinaries:
         MWCC_CC=MWCC_CC,
         AGBCC=AGBCC,
         SH_CC=SH_CC,
+        SHC_CC=SHC_CC,
         WINE=WINE,
     )
 
@@ -170,12 +178,41 @@ def get_sh_compilers(paths: PathsToBinaries) -> List[Tuple[str, Compiler]]:
     return []
 
 
+def get_shc_compilers(paths: PathsToBinaries) -> List[Tuple[str, Compiler]]:
+    if paths.SHC_CC is not None:
+        shc = Compiler(
+            name="shc",
+            cc_command=[
+                str(paths.SHC_CC),
+                "-comment=nonest",
+                "-cpu=sh4",
+                "-division=cpu",
+                "-endian=little",
+                "-fpu=single",
+                "-macsave=0",
+                "-sjis",
+                "-string=const",
+            ],
+        )
+        return [
+            (
+                "sh4-shc-o1",
+                shc.with_cc_flags(
+                    ["-optimize=1", "-speed", "-aggressive=2", "-code=asmcode"]
+                ),
+            )
+        ]
+    logger.warning("SHC compiler not found; skipping")
+    return []
+
+
 def get_compilers(paths: PathsToBinaries) -> List[Tuple[str, Compiler]]:
     compilers: List[Tuple[str, Compiler]] = []
     compilers.extend(get_ido_compilers(paths))
     compilers.extend(get_mwcc_compilers(paths))
     compilers.extend(get_agbcc_compilers(paths))
     compilers.extend(get_sh_compilers(paths))
+    compilers.extend(get_shc_compilers(paths))
     return compilers
 
 
@@ -212,7 +249,12 @@ def do_compilation_step(
 def run_compile(in_file: Path, out_file: Path, compiler: Compiler) -> None:
     flags_str = " ".join(compiler.cc_command)
     logger.info(f"Compiling {in_file} to {out_file} using: {flags_str}")
-    if compiler.name in ("agbcc", "sh-gcc"):
+    if compiler.name == "shc":
+        with NamedTemporaryFile(suffix=".src") as temp_src_file:
+            do_compilation_step(temp_src_file.name, str(in_file), compiler)
+            hitachi_asm = Path(temp_src_file.name).read_text()
+        out_file.write_text(shc_to_gas.convert(hitachi_asm))
+    elif compiler.name in ("agbcc", "sh-gcc"):
         with NamedTemporaryFile(suffix=".i") as temp_i_file:
             subprocess.run(
                 ["cpp", "-P", "-o", temp_i_file.name, str(in_file)], check=True
@@ -261,7 +303,7 @@ def add_test_from_file(
             continue
         try:
             run_compile(orig_file, asm_file_path, compiler)
-            if compiler.name in ("mwcc", "agbcc", "sh-gcc"):
+            if compiler.name in ("mwcc", "agbcc", "sh-gcc", "shc"):
                 # If the flags file doesn't exist, initialize it with the correct --target
                 flags_path = test_dir / (asm_filename + "-flags.txt")
                 if not flags_path.exists():
@@ -269,6 +311,8 @@ def add_test_from_file(
                         target = "ppc-mwcc-c"
                     elif compiler.name == "agbcc":
                         target = "gba"
+                    elif compiler.name == "shc":
+                        target = "sh4-shc-c"
                     else:
                         target = "sh2-gcc-c"
                     flags_path.write_text(f"--target {target}\n")

--- a/tests/add_test.py
+++ b/tests/add_test.py
@@ -192,14 +192,13 @@ def get_shc_compilers(paths: PathsToBinaries) -> List[Tuple[str, Compiler]]:
                 "-macsave=0",
                 "-sjis",
                 "-string=const",
+                "-code=asmcode",
             ],
         )
         return [
             (
                 "sh4-shc-o1",
-                shc.with_cc_flags(
-                    ["-optimize=1", "-speed", "-aggressive=2", "-code=asmcode"]
-                ),
+                shc.with_cc_flags(["-optimize=1", "-speed", "-aggressive=2"]),
             )
         ]
     logger.warning("SHC compiler not found; skipping")

--- a/tests/end_to_end/sh4-target/orig.c
+++ b/tests/end_to_end/sh4-target/orig.c
@@ -1,0 +1,6 @@
+int test(int a, int b) {
+    if (a > b) {
+        return a - b;
+    }
+    return a + b;
+}

--- a/tests/end_to_end/sh4-target/sh4-shc-o1-flags.txt
+++ b/tests/end_to_end/sh4-target/sh4-shc-o1-flags.txt
@@ -1,0 +1,1 @@
+--target sh4-shc-c

--- a/tests/end_to_end/sh4-target/sh4-shc-o1-out.c
+++ b/tests/end_to_end/sh4-target/sh4-shc-o1-out.c
@@ -1,0 +1,6 @@
+s32 test(s32 arg0, s32 arg1) {
+    if (arg0 > arg1) {
+        return arg0 - arg1;
+    }
+    return arg0 + arg1;
+}

--- a/tests/end_to_end/sh4-target/sh4-shc-o1.s
+++ b/tests/end_to_end/sh4-target/sh4-shc-o1.s
@@ -1,0 +1,17 @@
+.globl _test
+.section .text,"ax",@progbits
+.balign 4
+_test:                            ! function: test
+                                  ! frame size=0
+          CMP/GT      R5,R4
+          BF          L237
+          MOV         R4,R0
+          RTS
+          SUB         R5,R0
+L237:                             
+          MOV         R4,R0
+          ADD         R5,R0
+L238:                             
+          RTS
+          NOP
+

--- a/tests/shc_to_gas.py
+++ b/tests/shc_to_gas.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Convert SHC assembly to GNU as format.
+SHC's directives, comment markers, hex literals, and a couple of mnemonics are
+problematic
+
+Example:
+
+        .EXPORT _test
+        .SECTION    P,CODE,ALIGN=4
+    _test:                  ; function: test
+        MOV.L       L238,R1
+        FMOV.S      FR4,FR5
+        RTS
+        NOP
+        .SECTION    D,DATA,ALIGN=4
+    L238:
+        .DATA.L     H'1234
+        .END
+
+becomes:
+
+    .globl _test
+    .section .text,"ax",@progbits
+    .balign 4
+    _test:                   ! function: test
+        MOV.L       L238,R1
+        FMOV FR4,FR5
+        RTS
+        NOP
+    .section .data,"aw",@progbits
+    .balign 4
+    L238:
+    .long 0x1234
+"""
+
+import sys
+from typing import List, Optional, Tuple
+
+
+def is_hex_digit(c: str) -> bool:
+    return c in "0123456789abcdefABCDEF"
+
+
+def hex_converted(text: str) -> str:
+    """convert H'1234 into GNU as syntax 0x1234"""
+    out = []
+    i = 0
+
+    while i < len(text):
+        if (
+            i + 2 < len(text)
+            and text[i].upper() == "H"
+            and text[i + 1] == "'"
+            and is_hex_digit(text[i + 2])
+        ):
+            out.append("0x")
+            i += 2
+
+            while i < len(text) and is_hex_digit(text[i]):
+                out.append(text[i])
+                i += 1
+        else:
+            out.append(text[i])
+            i += 1
+
+    return "".join(out)
+
+
+def parse_fr(s: str, pos: int) -> Optional[Tuple[int, str]]:
+    """parse a floating point register name (FR0 - FR15) at s[pos:]"""
+    while pos < len(s) and s[pos].isspace():
+        pos += 1
+
+    start = pos
+
+    if pos + 2 > len(s) or s[pos : pos + 2].upper() != "FR":
+        return None
+
+    pos += 2
+    digits_start = pos
+
+    while pos < len(s) and s[pos].isdigit():
+        pos += 1
+
+    if pos == digits_start:
+        return None
+
+    return pos, s[start:pos]
+
+
+def convert_fmov_reg_reg(raw: str) -> Optional[str]:
+    """FMOV.S FRn,FRm -> FMOV FRn,FRm"""
+    for i in range(max(0, len(raw) - 5)):
+        if i > 0:
+            prev = raw[i - 1]
+            if prev.isalnum() or prev == "_":
+                continue
+
+        if raw[i : i + 6].upper() != "FMOV.S":
+            continue
+
+        pos = i + 6
+
+        parsed = parse_fr(raw, pos)
+        if parsed is None:
+            continue
+
+        pos, r1 = parsed
+
+        while pos < len(raw) and raw[pos].isspace():
+            pos += 1
+
+        if pos >= len(raw) or raw[pos] != ",":
+            continue
+
+        pos += 1
+
+        parsed = parse_fr(raw, pos)
+        if parsed is None:
+            continue
+
+        pos, r2 = parsed
+
+        return raw[:i] + "FMOV " + r1 + "," + r2 + raw[pos:]
+
+    return None
+
+
+SECTION_NAMES: List[Tuple[str, str]] = [
+    ("P", ".text"),
+    ("C", ".rodata"),
+    ("D", ".data"),
+    ("B", ".bss"),
+]
+
+
+def gas_section_name(name: str) -> str:
+    for shc_name, gas_name in SECTION_NAMES:
+        if name.upper() == shc_name:
+            return gas_name
+
+    return name
+
+
+def parse_uint(s: str) -> Optional[int]:
+    s = s.strip()
+
+    if not s:
+        return None
+
+    if not all(c.isdigit() for c in s):
+        return None
+
+    return int(s, 10)
+
+
+def convert_line(line: str) -> str:
+    if line.endswith("\r"):
+        line = line[:-1]
+
+    semi = line.find(";")
+
+    if semi != -1:
+        converted = line[:semi]
+
+        if semi + 1 < len(line):
+            converted += " !" + line[semi + 1 :]
+
+        line = converted
+
+    s = line.strip()
+
+    if not s:
+        return ""
+
+    if s.upper().startswith((".EXPORT", ".IMPORT")):
+        is_export = s.upper().startswith(".EXPORT")
+        n = 7
+
+        if len(s) > n and s[n].isspace():
+            arg = s[n:].strip()
+
+            if arg:
+                return (".globl " if is_export else ".extern ") + arg
+
+    if s.upper().startswith(".SECTION") and len(s) > 8 and s[8].isspace():
+        rest = s[8:].strip()
+        comma1 = rest.find(",")
+
+        if comma1 == -1:
+            if rest and not any(c in " \t\r\n," for c in rest):
+                flags = ',"ax",@progbits' if rest.upper() == "P" else ',"aw",@progbits'
+
+                return ".section " + gas_section_name(rest) + flags
+
+        else:
+            name = rest[:comma1].strip()
+            after = rest[comma1 + 1 :].strip()
+
+            comma2 = after.find(",")
+
+            if comma2 == -1:
+                kind = after.strip()
+            else:
+                kind = after[:comma2].strip()
+
+            if name and kind.upper() in ("CODE", "DATA"):
+                result = ".section " + gas_section_name(name)
+
+                if kind.upper() == "CODE":
+                    result += ',"ax",@progbits'
+                else:
+                    result += ',"aw",@progbits'
+
+                if comma2 != -1:
+                    tail = after[comma2 + 1 :].strip()
+
+                    if tail.upper().startswith("ALIGN="):
+                        align = parse_uint(tail[6:])
+
+                        if align is not None:
+                            result += "\n.balign " + str(align)
+
+                return result
+
+    if (
+        len(s) >= 8
+        and s.upper().startswith(".DATA.")
+        and s[6].upper() in ("B", "W", "L")
+        and s[7].isspace()
+    ):
+        size = s[6].upper()
+        val = s[7:].strip()
+
+        bang = val.find("!")
+
+        if bang != -1:
+            val = val[:bang].strip()
+
+        if size == "B":
+            directive = ".byte "
+        elif size == "W":
+            directive = ".word "
+        else:
+            directive = ".long "
+
+        return directive + hex_converted(val)
+
+    if s.upper().startswith(".END") and (
+        len(s) == 4 or (len(s) > 4 and s[4].isspace())
+    ):
+        return ""
+
+    if s.startswith("."):
+        raise ValueError("unsupported SHC directive: " + line)
+
+    fmov = convert_fmov_reg_reg(line)
+
+    if fmov is not None:
+        return hex_converted(fmov)
+
+    return hex_converted(line)
+
+
+def convert(text: str) -> str:
+    return "".join(convert_line(line) + "\n" for line in text.splitlines())
+
+
+def main() -> int:
+    try:
+        sys.stdout.write(convert(sys.stdin.read()))
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/shc_to_gas.py
+++ b/tests/shc_to_gas.py
@@ -33,97 +33,24 @@ becomes:
     .long 0x1234
 """
 
+import re
 import sys
 from typing import List, Optional, Tuple
 
 
-def is_hex_digit(c: str) -> bool:
-    return c in "0123456789abcdefABCDEF"
-
-
 def hex_converted(text: str) -> str:
     """convert H'1234 into GNU as syntax 0x1234"""
-    out = []
-    i = 0
-
-    while i < len(text):
-        if (
-            i + 2 < len(text)
-            and text[i].upper() == "H"
-            and text[i + 1] == "'"
-            and is_hex_digit(text[i + 2])
-        ):
-            out.append("0x")
-            i += 2
-
-            while i < len(text) and is_hex_digit(text[i]):
-                out.append(text[i])
-                i += 1
-        else:
-            out.append(text[i])
-            i += 1
-
-    return "".join(out)
+    return re.sub(r"h'(?=[0-9a-f])", "0x", text, flags=re.IGNORECASE)
 
 
-def parse_fr(s: str, pos: int) -> Optional[Tuple[int, str]]:
-    """parse a floating point register name (FR0 - FR15) at s[pos:]"""
-    while pos < len(s) and s[pos].isspace():
-        pos += 1
-
-    start = pos
-
-    if pos + 2 > len(s) or s[pos : pos + 2].upper() != "FR":
-        return None
-
-    pos += 2
-    digits_start = pos
-
-    while pos < len(s) and s[pos].isdigit():
-        pos += 1
-
-    if pos == digits_start:
-        return None
-
-    return pos, s[start:pos]
-
-
-def convert_fmov_reg_reg(raw: str) -> Optional[str]:
+def convert_fmov_reg_reg(raw: str) -> str:
     """FMOV.S FRn,FRm -> FMOV FRn,FRm"""
-    for i in range(max(0, len(raw) - 5)):
-        if i > 0:
-            prev = raw[i - 1]
-            if prev.isalnum() or prev == "_":
-                continue
-
-        if raw[i : i + 6].upper() != "FMOV.S":
-            continue
-
-        pos = i + 6
-
-        parsed = parse_fr(raw, pos)
-        if parsed is None:
-            continue
-
-        pos, r1 = parsed
-
-        while pos < len(raw) and raw[pos].isspace():
-            pos += 1
-
-        if pos >= len(raw) or raw[pos] != ",":
-            continue
-
-        pos += 1
-
-        parsed = parse_fr(raw, pos)
-        if parsed is None:
-            continue
-
-        pos, r2 = parsed
-
-        return raw[:i] + "FMOV " + r1 + "," + r2 + raw[pos:]
-
-    return None
+    return re.sub(
+        r"\bFMOV\.S(\s+FR\d+\s*,\s*FR\d+)",
+        r"FMOV\1",
+        raw,
+        flags=re.IGNORECASE,
+    )
 
 
 SECTION_NAMES: List[Tuple[str, str]] = [
@@ -155,18 +82,12 @@ def parse_uint(s: str) -> Optional[int]:
 
 
 def convert_line(line: str) -> str:
-    if line.endswith("\r"):
-        line = line[:-1]
+    line = line.rstrip("\r")
 
     semi = line.find(";")
 
     if semi != -1:
-        converted = line[:semi]
-
-        if semi + 1 < len(line):
-            converted += " !" + line[semi + 1 :]
-
-        line = converted
+        line = line[:semi] + " !" + line[semi + 1 :]
 
     s = line.strip()
 
@@ -254,12 +175,7 @@ def convert_line(line: str) -> str:
     if s.startswith("."):
         raise ValueError("unsupported SHC directive: " + line)
 
-    fmov = convert_fmov_reg_reg(line)
-
-    if fmov is not None:
-        return hex_converted(fmov)
-
-    return hex_converted(line)
+    return hex_converted(convert_fmov_reg_reg(line))
 
 
 def convert(text: str) -> str:

--- a/tests/shc_to_gas.py
+++ b/tests/shc_to_gas.py
@@ -84,10 +84,7 @@ def parse_uint(s: str) -> Optional[int]:
 def convert_line(line: str) -> str:
     line = line.rstrip("\r")
 
-    semi = line.find(";")
-
-    if semi != -1:
-        line = line[:semi] + " !" + line[semi + 1 :]
+    line = line.replace(";", " !", 1)
 
     s = line.strip()
 


### PR DESCRIPTION
This adds some plumbing for sh4 and generating e2e tests. I'm using this https://github.com/decompme/compilers/blob/main/platforms/dreamcast/shc-v5.1r03/Dockerfile
A script is added to convert SHC syntax to GNU asm. AFAIK there's no precedent in m2c for alternative assembler syntaxes so I assumed this would be the preferred approach.
An e2e test is added to test the SHC output.
Sh4Arch is just empty at the moment and falls back to sh2. It's a superset of the sh2 instruction set so this is fine.